### PR TITLE
#2: Add support for RTL languages in tweet content

### DIFF
--- a/lib/tweet.dart
+++ b/lib/tweet.dart
@@ -1,3 +1,4 @@
+import 'package:auto_direction/auto_direction.dart';
 import 'package:better_player/better_player.dart';
 import 'package:flutter/gestures.dart';
 import 'package:fritter/models.dart';
@@ -191,12 +192,17 @@ class TweetTile extends StatelessWidget {
 
                             return null;
                           },
-                          child: Padding(
+                          child: Container(
+                            // Fill the width so both RTL and LTR text are displayed correctly
+                            width: double.infinity,
                             padding: EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-                            child: RichText(
-                              text: TextSpan(
-                                style: Theme.of(context).textTheme.subtitle1,
-                                children: contentWidgets
+                            child: AutoDirection(
+                              text: tweet.content,
+                              child: RichText(
+                                text: TextSpan(
+                                    style: Theme.of(context).textTheme.subtitle1,
+                                    children: contentWidgets
+                                ),
                               ),
                             ),
                           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -22,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.5.0-nullsafety.1"
+  auto_direction:
+    dependency: "direct main"
+    description:
+      name: auto_direction
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4+1"
   better_player:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
+  auto_direction: ^0.0.4+1
   better_player: ^0.0.49
   html: ^0.14.0+4
   http: ^0.12.2


### PR DESCRIPTION
This should fix #2. It uses a widget that detects the direction a given string should be displayed in, and automatically changes the child widget(s) to follow that direction.

Before:
<p float="left">
<img src="https://user-images.githubusercontent.com/456645/111320377-d09e1180-865e-11eb-9b6d-29b8a2fb82e6.png" width="300">
<img src="https://user-images.githubusercontent.com/456645/111320384-d1cf3e80-865e-11eb-879d-b9bcccf5ac4d.png" width="300">
</p>

After:
<p float="left">
<img src="https://user-images.githubusercontent.com/456645/111320424-dac01000-865e-11eb-88e8-71f1e61a9ffe.png" width="300">
<img src="https://user-images.githubusercontent.com/456645/111320429-db58a680-865e-11eb-8e80-d7bc882b2201.png" width="300">
</p>