### PR TITLE
Added option to set the app theme manually

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,3 +1,2 @@
-import 'models.dart';
-
+const OPTION_THEME_MODE = 'theme.mode';
 const OPTION_THEME_TRUE_BLACK = 'theme.true_black';

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -18,7 +18,24 @@ class _OptionsScreenState extends State<OptionsScreen> {
         future: SharedPreferences.getInstance(),
         builder: (context, snapshot) {
           return PrefPage(children: [
-            PrefTitle(title: Text('Theme')),
+            PrefTitle(
+              title: Text('Theme')
+            ),
+            PrefRadio(
+              title: Text('System Theme'),
+              value: 'system',
+              pref: OPTION_THEME_MODE,
+            ),
+            PrefRadio(
+              title: Text('Light Theme'),
+              value: 'light',
+              pref: OPTION_THEME_MODE,
+            ),
+            PrefRadio(
+              title: Text('Dark Theme'),
+              value: 'dark',
+              pref: OPTION_THEME_MODE,
+            ),
             PrefSwitch(
               title: Text('True Black?'),
               pref: OPTION_THEME_TRUE_BLACK,


### PR DESCRIPTION
This adds a new option that allows the user to manually choose the app's theme. This is useful on older devices where Android might not support a native dark mode, and so the user can enable it on a per-app basis.

<p style="float: left">
<img src="https://user-images.githubusercontent.com/456645/115293440-39414800-a14f-11eb-9c2c-9dbfaa2123fd.jpg" width="250" />
<img src="https://user-images.githubusercontent.com/456645/115293443-39d9de80-a14f-11eb-8d30-dfe3425a4c30.jpg" width="250" />
<img src="https://user-images.githubusercontent.com/456645/115293444-3a727500-a14f-11eb-8bb2-8c1b5fdf5f44.jpg" width="250" />
</p>