### PR TITLE
Add support for linked entities (mentions, hashtags and URLs)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,4 +60,15 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
 </manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.32'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -46,5 +46,10 @@
       <key>NSAllowsArbitraryLoads</key>
       <true/>
     </dict>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+      <string>https</string>
+      <string>http</string>
+    </array>
 </dict>
 </plist>

--- a/lib/home/_search.dart
+++ b/lib/home/_search.dart
@@ -5,6 +5,10 @@ import 'package:fritter/tweet.dart';
 import 'package:fritter/user.dart';
 
 class TweetSearchDelegate extends SearchDelegate {
+  final int initialTab;
+
+  TweetSearchDelegate({ required this.initialTab });
+
   Future<List<Tweet>> searchTweets(BuildContext context, String query) async {
     if (query.isEmpty) {
       return [];
@@ -44,6 +48,7 @@ class TweetSearchDelegate extends SearchDelegate {
   Widget buildResults(BuildContext context) {
     return DefaultTabController(
         length: 2,
+        initialIndex: initialTab,
         child: Column(
           children: [
             Container(

--- a/lib/home/_trends.dart
+++ b/lib/home/_trends.dart
@@ -52,7 +52,9 @@ class TrendsContent extends StatelessWidget {
                         onTap: () async {
                           await showSearch(
                               context: context,
-                              delegate: TweetSearchDelegate(),
+                              delegate: TweetSearchDelegate(
+                                initialTab: 1
+                              ),
                               query: Uri.decodeQueryComponent(trend.query!)
                           );
                         },

--- a/lib/home/home_screen.dart
+++ b/lib/home/home_screen.dart
@@ -60,7 +60,9 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
           IconButton(
             icon: Icon(Icons.search),
             onPressed: () {
-              showSearch(context: context, delegate: TweetSearchDelegate());
+              showSearch(context: context, delegate: TweetSearchDelegate(
+                initialTab: 0
+              ));
             },
           ),
           IconButton(

--- a/lib/tweet.dart
+++ b/lib/tweet.dart
@@ -1,9 +1,12 @@
+import 'dart:developer';
+
 import 'package:auto_direction/auto_direction.dart';
 import 'package:dart_twitter_api/twitter_api.dart';
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:fritter/status.dart';
+import 'package:fritter/tweet/_content.dart';
 import 'package:intl/intl.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:video_player/video_player.dart';
@@ -163,46 +166,19 @@ class TweetTile extends StatelessWidget {
     }
 
     return Builder(builder: (context) {
-      List<InlineSpan> contentWidgets = [];
-
       var tweetText = tweet.fullText == null
-        ? tweet.text
-        : tweet.fullText;
+          ? tweet.text
+          : tweet.fullText;
 
       if (tweetText == null) {
         var message = 'The tweet did not contain any text. This is unexpected';
 
-        print(message);
+        log(message);
 
         return Container(child: Text(
             'The tweet did not contain any text. This is unexpected'
         ));
       }
-
-      // Split the string by any mentions, and turn those mentions into links to the profile
-      tweetText.splitMapJoin(RegExp(r'\B\@([\w\-]+)'),
-          onMatch: (match) {
-            var username = match.group(1) ?? '';
-
-            contentWidgets.add(TextSpan(
-                text: '@$username',
-                style: TextStyle(color: Theme.of(context).accentColor),
-                recognizer: TapGestureRecognizer()
-                  ..onTap = () {
-                    Navigator.push(context, MaterialPageRoute(builder: (context) => ProfileScreen(username: username)));
-                  }
-            ));
-
-            return username;
-          },
-          onNonMatch: (text) {
-            contentWidgets.add(TextSpan(
-                text: text
-            ));
-
-            return text;
-          }
-      );
 
       var quotedTweet = Container();
       if (tweet.isQuoteStatus ?? false) {
@@ -279,11 +255,11 @@ class TweetTile extends StatelessWidget {
                             padding: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
                             child: AutoDirection(
                               text: tweetText,
-                              child: RichText(
-                                text: TextSpan(
-                                    style: Theme.of(context).textTheme.subtitle1,
-                                    children: contentWidgets
-                                ),
+                              child: TweetContent(
+                                text: tweetText,
+                                urls: tweet.entities?.urls ?? [],
+                                mentions: tweet.entities?.userMentions ?? [],
+                                hashtags: tweet.entities?.hashtags ?? []
                               ),
                             ),
                           ),

--- a/lib/tweet/_content.dart
+++ b/lib/tweet/_content.dart
@@ -1,0 +1,154 @@
+import 'package:dart_twitter_api/twitter_api.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:fritter/profile.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+abstract class TweetEntity {
+  List<int>? indices;
+
+  TweetEntity(this.indices);
+
+  InlineSpan getContent();
+
+  int getEntityStart() {
+    return indices![0];
+  }
+
+  int getEntityEnd() {
+    return indices![1];
+  }
+}
+
+class TweetHashtag extends TweetEntity {
+  final Hashtag hashtag;
+  final Function onTap;
+
+  TweetHashtag(this.hashtag, this.onTap): super(hashtag.indices);
+
+  @override
+  InlineSpan getContent() {
+    return TextSpan(
+        text: '#${hashtag.text}',
+        style: TextStyle(color: Colors.blue),
+        recognizer: TapGestureRecognizer()..onTap = () {
+          onTap();
+        }
+    );
+  }
+}
+
+class TweetUserMention extends TweetEntity {
+  final UserMention mention;
+  final Function onTap;
+
+  TweetUserMention(this.mention, this.onTap): super(mention.indices);
+
+  @override
+  InlineSpan getContent() {
+    return TextSpan(
+        text: '@${mention.screenName}',
+        style: TextStyle(color: Colors.blue),
+        recognizer: TapGestureRecognizer()..onTap = () {
+          onTap();
+        }
+    );
+  }
+}
+
+class TweetUrl extends TweetEntity {
+  final Url url;
+  final Function onTap;
+
+  TweetUrl(this.url, this.onTap): super(url.indices);
+
+  @override
+  InlineSpan getContent() {
+    return TextSpan(
+        text: url.displayUrl,
+        style: TextStyle(color: Colors.blue),
+        recognizer: TapGestureRecognizer()..onTap = () {
+          onTap();
+        }
+    );
+  }
+}
+
+extension IterableRange<T> on Iterable<T> {
+  Iterable<T> getRange(int start, [int? end]) {
+    return (end != null ? this.take(end) : this).skip(start);
+  }
+}
+
+class TweetContent extends StatelessWidget {
+  final String text;
+  final List<Url> urls;
+  final List<UserMention> mentions;
+  final List<Hashtag> hashtags;
+
+  TweetContent({ required this.text, required this.urls, required this.mentions, required this.hashtags });
+
+  @override
+  Widget build(BuildContext context) {
+    List<TweetEntity> entities = [];
+
+    for (var hashtag in hashtags) {
+      entities.add(TweetHashtag(hashtag, () {
+        int i = 0;
+        // Navigator.push(context, MaterialPageRoute(builder: (context) => ProfileScreen(username: username)));
+      }));
+    }
+
+    for (var mention in mentions) {
+      entities.add(TweetUserMention(mention, () {
+        Navigator.push(context, MaterialPageRoute(builder: (context) => ProfileScreen(id: mention.idStr, username: mention.screenName!)));
+      }));
+    }
+
+    for (var url in urls) {
+      entities.add(TweetUrl(url, () async {
+        var uri = url.expandedUrl;
+        if (uri == null) {
+          return;
+        }
+
+        await launch(uri);
+      }));
+    }
+
+    List<InlineSpan> parts = [];
+    var index = 0;
+    var runes = Runes(text);
+
+    entities.sort((a, b) => a.getEntityStart().compareTo(b.getEntityStart()));
+
+    var addText = (int start, [int? end]) {
+      var string = runes.getRange(start, end).map((e) => String.fromCharCode(e)).join('');
+      if (string.isEmpty) {
+        return;
+      }
+
+      parts.add(TextSpan(text: string, style: Theme.of(context).textTheme.bodyText2));
+    };
+
+    entities.forEach((part) {
+      // First, add any text between the last entity's end and the start of this one
+      addText(index, part.getEntityStart());
+
+      // Then add the actual entity
+      parts.add(part.getContent());
+
+      // Then set our index in the tweet text as the end of our entity
+      index = part.getEntityEnd();
+    });
+
+    // Finally, add any remaining tweet text
+    addText(index);
+
+    return RichText(
+      text: TextSpan(
+        children: parts
+      ),
+    );
+  }
+}

--- a/lib/tweet/_content.dart
+++ b/lib/tweet/_content.dart
@@ -1,6 +1,7 @@
 import 'package:dart_twitter_api/twitter_api.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:fritter/home/_search.dart';
 import 'package:fritter/profile.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -93,9 +94,14 @@ class TweetContent extends StatelessWidget {
     List<TweetEntity> entities = [];
 
     for (var hashtag in hashtags) {
-      entities.add(TweetHashtag(hashtag, () {
-        int i = 0;
-        // Navigator.push(context, MaterialPageRoute(builder: (context) => ProfileScreen(username: username)));
+      entities.add(TweetHashtag(hashtag, () async {
+        await showSearch(
+            context: context,
+            delegate: TweetSearchDelegate(
+              initialTab: 1
+            ),
+            query: Uri.decodeQueryComponent('#${hashtag.text}')
+        );
       }));
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -546,6 +546,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0+2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   sqflite_migration_plan: ^0.1.0
   timeago: ^3.0.2
   uni_links2: ^0.6.0+2
+  url_launcher: ^6.0.3
   video_player: ^2.1.1
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
This adds support for displaying and opening **mentions**, **hashtags** and **URLs**.

* When selecting a user mention, the user's profile is opened in a new activity.
* When selecting a hashtag, the standard search dialog is opened, and prepopulated with the hashtag (haven't worked out how to automatically search yet)
* When selecting a URL, the registered Android URL handler is opened (browser or app)

Before and after:
<p style="float: left">
<img src="https://user-images.githubusercontent.com/456645/115775190-76eddd00-a3aa-11eb-86b4-9577b5c4d03e.jpg" width="300" />
<img src="https://user-images.githubusercontent.com/456645/115774576-acde9180-a3a9-11eb-8e92-2f98452c6649.jpg" width="300" />
</p>