### PR TITLE
Added support for sharing tweet content and links

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/next.txt
+++ b/fastlane/metadata/android/en-US/changelogs/next.txt
@@ -1,4 +1,5 @@
 * Added support for saving tweets locally
+* Added support for sharing links to tweets, and sharing tweet content
 * Added opt-in button to submit a one-time non-identifying ping to help future development
 * Added a more detailed message when the Twitter API token cannot be refreshed
 * Fixed some tweet URLs not launching the app correctly

--- a/lib/tweet.dart
+++ b/lib/tweet.dart
@@ -10,6 +10,7 @@ import 'package:fritter/tweet/_card.dart';
 import 'package:fritter/tweet/_content.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:share/share.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:video_player/video_player.dart';
 
@@ -134,6 +135,7 @@ class TweetTile extends StatelessWidget {
     }
 
     var numberFormat = NumberFormat.compact();
+    var actionColour = Theme.of(context).disabledColor;
 
     TweetWithCard tweet = this.tweet!.retweetedStatusWithCard == null
       ? this.tweet!
@@ -295,18 +297,37 @@ class TweetTile extends StatelessWidget {
                           return _createFooterButton(Icons.bookmark_outline, 'Loading', null, null);
                         }
 
-                        var color = Theme.of(context).disabledColor;
-
                         if (saved) {
-                          return _createFooterButton(Icons.bookmark, 'Saved', color, () async {
+                          return _createFooterButton(Icons.bookmark, 'Saved', actionColour, () async {
                             await model.deleteSavedTweet(tweet.idStr!);
                           });
                         } else {
-                          return _createFooterButton(Icons.bookmark_outline, 'Save', color, () async {
+                          return _createFooterButton(Icons.bookmark_outline, 'Save', actionColour, () async {
                             await model.saveTweet(tweet.idStr!, tweet.toJson());
                           });
                         }},
-                    )
+                    ),
+                    _createFooterButton(Icons.share, 'Share', actionColour, () async {
+                      var createShareDialogItem = (String text, String shareContent) => SimpleDialogOption(
+                        child: Container(
+                          margin: EdgeInsets.symmetric(vertical: 8),
+                          child: Text(text, style: TextStyle(
+                              fontSize: 16
+                          )),
+                        ),
+                        onPressed: () => Share.share(shareContent),
+                      );
+
+                      showDialog(context: context, builder: (context) {
+                        return SimpleDialog(
+                          contentPadding: EdgeInsets.symmetric(vertical: 8),
+                          children: [
+                            createShareDialogItem('Share tweet content', tweetText),
+                            createShareDialogItem('Share tweet link', 'https://twitter.com/${tweet.user!.screenName}/status/${tweet.idStr}'),
+                          ],
+                        );
+                      });
+                    }),
                   ],
                 )
               ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -275,6 +275,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   nested:
     dependency: transitive
     description:
@@ -424,6 +431,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "10.1.0"
+  share:
+    dependency: "direct main"
+    description:
+      name: share
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   shared_preferences:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   pref: ^2.0.2
   pull_to_refresh: 1.6.4-nullsafety.0
   reactive_forms: ^10.1.0
+  share: ^2.0.1
   sqflite: ^2.0.0+3
   sqflite_migration_plan: ^0.1.0
   timeago: ^3.0.2


### PR DESCRIPTION
This fixes #40 by adding a new "Share" button to all tweets, which when tapped, will bring up a dialog where the user can choose to share the tweet's content or a link to the tweet (pointing to `twitter.com`).
<p style="float: left">
  <img src="https://user-images.githubusercontent.com/456645/116884393-9b557f00-ac1e-11eb-9f6c-fa13948871e3.jpg" width="350" />
  <img src="https://user-images.githubusercontent.com/456645/116884398-9c86ac00-ac1e-11eb-905b-0870cd84f03e.jpg" width="350" />
</p>