### PR TITLE
Now displaying tweet media in a carousel

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/next.txt
+++ b/fastlane/metadata/android/en-US/changelogs/next.txt
@@ -1,3 +1,4 @@
+* Added support for importing and exporting subscriptions, groups, tweets and settings
 * Added support for saving tweets locally
 * Added support for sharing links to tweets, and sharing tweet content
 * Added opt-in button to submit a one-time non-identifying ping to help future development

--- a/lib/home_model.dart
+++ b/lib/home_model.dart
@@ -116,8 +116,8 @@ class HomeModel extends ChangeNotifier {
     var database = await Repository.readOnly();
 
     var orderByDirection = orderByAscending
-      ? 'ASC'
-      : 'DESC';
+      ? 'COLLATE NOCASE ASC'
+      : 'COLLATE NOCASE DESC';
 
     return (await database.query(TABLE_SUBSCRIPTION, orderBy: '$orderBy $orderByDirection'))
         .map((e) => Subscription.fromMap(e))


### PR DESCRIPTION
This adds support for displaying tweet media inside a carousel, instead of one after the other in a big column. This will save space on device screens, and give a better UX for viewing multiple images in a tweet.

Fixes #44.

Before and after:

<p style="float: left">
<img src="https://user-images.githubusercontent.com/456645/117487949-ad5b5880-af63-11eb-86ea-93f3e1506aea.jpg" width="350" />
<img src="https://user-images.githubusercontent.com/456645/117487952-ae8c8580-af63-11eb-9a57-c62c5121df19.jpg" width="350" />
</p>