### PR TITLE
Add support for update notifications

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,7 +35,7 @@ jobs:
           flutter config --no-analytics
           flutter pub get
           flutter pub run flutter_oss_licenses:generate.dart
-          flutter build apk
+          flutter build apk --dart-define=app.flavor=github
         env:
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           flutter config --no-analytics
           flutter pub get
           flutter pub run flutter_oss_licenses:generate.dart
-          flutter build apk
+          flutter build apk --dart-define=app.flavor=github
         env:
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,6 +54,7 @@ android {
         applicationId "com.jonjomckay.fritter"
         minSdkVersion 16
         targetSdkVersion 30
+        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
@@ -91,5 +92,6 @@ flutter {
 }
 
 dependencies {
+    implementation "androidx.multidex:multidex:2.0.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="com.jonjomckay.flitter.FritterApplication"
         android:label="@string/app_name"
         android:icon="@mipmap/launcher_icon">
         <activity

--- a/android/app/src/main/kotlin/com/jonjomckay/flitter/FritterApplication.java
+++ b/android/app/src/main/kotlin/com/jonjomckay/flitter/FritterApplication.java
@@ -1,0 +1,15 @@
+package com.jonjomckay.flitter;
+
+import android.content.Context;
+import androidx.multidex.MultiDex;
+
+import io.flutter.app.FlutterApplication;
+
+public class FritterApplication extends FlutterApplication {
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+        MultiDex.install(this);
+    }
+}

--- a/fastlane/metadata/android/en-US/changelogs/hotfix.txt
+++ b/fastlane/metadata/android/en-US/changelogs/hotfix.txt
@@ -1,1 +1,0 @@
-* Fixed tapping on usernames in tweets opening two screens. Replies are now viewable by tapping the replies icon underneath a tweet

--- a/fastlane/metadata/android/en-US/changelogs/next.txt
+++ b/fastlane/metadata/android/en-US/changelogs/next.txt
@@ -1,2 +1,3 @@
 * Now displaying subscriptions as the first page instead of trends
+* Now notifying the user when an update to the app is available
 * Added "Tweets" and "Tweets & Replies" tabs to profiles

--- a/lib/home/home_screen.dart
+++ b/lib/home/home_screen.dart
@@ -1,4 +1,3 @@
-
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 import 'package:fritter/database/entities.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,12 @@ Future checkForUpdates() async {
       var package = await PackageInfo.fromPlatform();
       var result = jsonDecode(response.body);
 
-      const flavor = String.fromEnvironment('app.flavor');
+      const appFlavor = String.fromEnvironment('app.flavor');
+
+      var flavor = appFlavor == ''
+        ? 'fdroid'
+        : appFlavor;
+
       var release = result['versions'][flavor]['stable'];
       var latest = release['versionCode'];
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,9 +158,11 @@ packages:
   file_picker_writable:
     dependency: "direct main"
     description:
-      name: file_picker_writable
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "."
+      ref: "45b55f13266de97e7f02fb05b49dbccfb492c4cc"
+      resolved-ref: "45b55f13266de97e7f02fb05b49dbccfb492c4cc"
+      url: "https://github.com/jonjomckay/file_picker_writable.git"
+    source: git
     version: "2.0.0"
   flex_color_scheme:
     dependency: "direct main"
@@ -181,6 +183,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.0+4"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   flutter_oss_licenses:
     dependency: "direct dev"
     description:
@@ -581,6 +597,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,11 @@ dependencies:
   extended_image: ^4.0.1
   faker: ^2.0.0-rc.2
   flex_color_scheme: ^2.1.1
-  file_picker_writable: ^2.0.0
+  file_picker_writable:
+    git:
+      url: https://github.com/jonjomckay/file_picker_writable.git
+      ref: 45b55f13266de97e7f02fb05b49dbccfb492c4cc
+  flutter_local_notifications: ^5.0.0+4
   html_unescape: ^2.0.0
   http: ^0.13.1
   infinite_scroll_pagination: ^3.0.1


### PR DESCRIPTION
This adds support for notifying the user when a new version is available. It supports both when the app is installed from F-Droid, and from GitHub.

When installed from F-Droid, tapping the notification will open the user's F-Droid client, and when installed from GitHub, the notification will download the APK directly from GitHub releases. Either way, the installation is still manual, so Fritter itself needs no extra permissions.

This fixes #65.

<p style="float: left">
<img src="https://user-images.githubusercontent.com/456645/118028809-67373800-b35b-11eb-938e-919601e5fb53.png" width="350" />
<img src="https://user-images.githubusercontent.com/456645/118028813-68686500-b35b-11eb-80c2-a4e104554069.png" width="350" />
</p>