### PR TITLE
Add support for selecting the media size

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/next.txt
+++ b/fastlane/metadata/android/en-US/changelogs/next.txt
@@ -1,3 +1,4 @@
 * Added support for selecting the default tab when the app opens
+* Added support for selecting the media size
 * Now showing who a tweet is in reply to
 * Fixed not being able to select non-Latin hashtags

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -2,6 +2,9 @@ const OPTION_HELLO_LAST_BUILD = 'hello.last_build';
 
 const OPTION_HOME_INITIAL_TAB = 'home.initial_tab';
 
+const OPTION_MEDIA_ENABLE = 'media.enable';
+const OPTION_MEDIA_SIZE = 'media.size';
+
 const OPTION_SUBSCRIPTION_ORDER_BY_ASCENDING = 'subscription.order_by.ascending';
 const OPTION_SUBSCRIPTION_ORDER_BY_FIELD = 'subscription.order_by.field';
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -2,7 +2,6 @@ const OPTION_HELLO_LAST_BUILD = 'hello.last_build';
 
 const OPTION_HOME_INITIAL_TAB = 'home.initial_tab';
 
-const OPTION_MEDIA_ENABLE = 'media.enable';
 const OPTION_MEDIA_SIZE = 'media.size';
 
 const OPTION_SUBSCRIPTION_ORDER_BY_ASCENDING = 'subscription.order_by.ascending';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -93,6 +93,8 @@ Future<void> main() async {
   }
 
   final prefService = await PrefServiceShared.init(prefix: 'pref_', defaults: {
+    OPTION_MEDIA_ENABLE: true,
+    OPTION_MEDIA_SIZE: 'medium',
     OPTION_THEME_MODE: 'system',
     OPTION_THEME_TRUE_BLACK: false
   });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -93,7 +93,6 @@ Future<void> main() async {
   }
 
   final prefService = await PrefServiceShared.init(prefix: 'pref_', defaults: {
-    OPTION_MEDIA_ENABLE: true,
     OPTION_MEDIA_SIZE: 'medium',
     OPTION_THEME_MODE: 'system',
     OPTION_THEME_TRUE_BLACK: false

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -217,6 +217,23 @@ class _OptionsScreenState extends State<OptionsScreen> {
               .map((e) => DropdownMenuItem(child: Text(e.title), value: e.id))
               .toList()
         ),
+        PrefCheckbox(
+          pref: OPTION_MEDIA_ENABLE,
+          title: Text('Display media'),
+          subtitle: Text('Whether to automatically display media'),
+        ),
+        PrefDropdown(
+          fullWidth: false,
+          title: Text('Media size'),
+          subtitle: Text('Save bandwidth using smaller images'),
+          pref: OPTION_MEDIA_SIZE,
+          items: [
+            DropdownMenuItem(child: Text('Thumbnail'), value: 'thumb'),
+            DropdownMenuItem(child: Text('Small'), value: 'small'),
+            DropdownMenuItem(child: Text('Medium'), value: 'medium'),
+            DropdownMenuItem(child: Text('Large'), value: 'large'),
+          ]
+        ),
 
         PrefTitle(
             title: Text('Theme')

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -217,17 +217,13 @@ class _OptionsScreenState extends State<OptionsScreen> {
               .map((e) => DropdownMenuItem(child: Text(e.title), value: e.id))
               .toList()
         ),
-        PrefCheckbox(
-          pref: OPTION_MEDIA_ENABLE,
-          title: Text('Display media'),
-          subtitle: Text('Whether to automatically display media'),
-        ),
         PrefDropdown(
           fullWidth: false,
           title: Text('Media size'),
           subtitle: Text('Save bandwidth using smaller images'),
           pref: OPTION_MEDIA_SIZE,
           items: [
+            DropdownMenuItem(child: Text('Disabled'), value: 'disabled'),
             DropdownMenuItem(child: Text('Thumbnail'), value: 'thumb'),
             DropdownMenuItem(child: Text('Small'), value: 'small'),
             DropdownMenuItem(child: Text('Medium'), value: 'medium'),

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -198,18 +198,19 @@ class _OptionsScreenState extends State<OptionsScreen> {
     return Scaffold(
       appBar: AppBar(),
       body: PrefPage(children: [
-        PrefTitle(
-          title: Text('General'),
-        ),
         PrefButton(
           child: Text('👋 Hello'),
           title: Text('Say Hello'),
           subtitle: Text('Send a non-identifying ping to let me know you\'re using Fritter, and to help future development'),
           onTap: _sendPing,
         ),
+
+        PrefTitle(
+          title: Text('General'),
+        ),
         PrefDropdown(
           fullWidth: false,
-          title: Text('Default Tab'),
+          title: Text('Default tab'),
           subtitle: Text('Which tab is shown when the app opens'),
           pref: OPTION_HOME_INITIAL_TAB,
           items: homeTabs
@@ -220,20 +221,15 @@ class _OptionsScreenState extends State<OptionsScreen> {
         PrefTitle(
             title: Text('Theme')
         ),
-        PrefRadio(
-          title: Text('System Theme'),
-          value: 'system',
+        PrefDropdown(
+          fullWidth: false,
+          title: Text('Theme'),
           pref: OPTION_THEME_MODE,
-        ),
-        PrefRadio(
-          title: Text('Light Theme'),
-          value: 'light',
-          pref: OPTION_THEME_MODE,
-        ),
-        PrefRadio(
-          title: Text('Dark Theme'),
-          value: 'dark',
-          pref: OPTION_THEME_MODE,
+          items: [
+            DropdownMenuItem(child: Text('System'), value: 'system'),
+            DropdownMenuItem(child: Text('Light'), value: 'light'),
+            DropdownMenuItem(child: Text('Dark'), value: 'dark'),
+          ]
         ),
         PrefSwitch(
           title: Text('True Black?'),

--- a/lib/tweet.dart
+++ b/lib/tweet.dart
@@ -38,19 +38,19 @@ class _TweetMediaItemState extends State<TweetMediaItem> {
   void initState() {
     super.initState();
 
-    var isMediaEnabled = PrefService.of(context, listen: false)
-      .get(OPTION_MEDIA_ENABLE);
+    var mediaSize = PrefService.of(context, listen: false)
+      .get(OPTION_MEDIA_SIZE);
 
-    if (isMediaEnabled) {
-      setState(() {
-        _showMedia = true;
-      });
-    } else {
+    if (mediaSize == 'disabled') {
       // If the image is cached already, show the media
       cachedImageExists(widget.media.mediaUrlHttps!)
           .then((value) => setState(() {
             _showMedia = value;
           }));
+    } else {
+      setState(() {
+        _showMedia = true;
+      });
     }
   }
 
@@ -154,7 +154,10 @@ class TweetPhoto extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var prefs = PrefService.of(context, listen: false);
-    var size = prefs.get(OPTION_MEDIA_SIZE) ?? 'medium';
+    var size = prefs.get(OPTION_MEDIA_SIZE);
+    if (size == 'disabled') {
+      size = 'medium';
+    }
 
     return ExtendedImage.network('$uri:$size',
         cache: true,

--- a/lib/tweet/_card.dart
+++ b/lib/tweet/_card.dart
@@ -4,7 +4,9 @@ import 'package:dart_twitter_api/twitter_api.dart';
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 import 'package:fritter/client.dart';
+import 'package:fritter/constants.dart';
 import 'package:intl/intl.dart';
+import 'package:pref/pref.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:url_launcher/url_launcher.dart';
 
@@ -179,9 +181,19 @@ class TweetCard extends StatelessWidget {
       return Container();
     }
 
+    var imageKey = '';
+    var imageSize = PrefService.of(context, listen: false).get(OPTION_MEDIA_SIZE);
+    if (imageSize == 'thumb') {
+      imageKey = '_small';
+    } else if (imageSize == 'medium') {
+      imageKey = '_large';
+    } else if (imageSize == 'large') {
+      imageKey = '_x_large';
+    }
+
     switch (card['name']) {
       case 'summary':
-        var image = card['binding_values']['thumbnail_image_large']?['image_value'];
+        var image = card['binding_values']['thumbnail_image$imageKey']?['image_value'];
 
         return _createCard(card, Row(
           children: [
@@ -190,7 +202,7 @@ class TweetCard extends StatelessWidget {
           ],
         ));
       case 'summary_large_image':
-        var image = card['binding_values']['summary_photo_image']?['image_value'];
+        var image = card['binding_values']['thumbnail_image$imageKey']?['image_value'];
 
         return _createCard(card, Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -204,7 +216,7 @@ class TweetCard extends StatelessWidget {
           ],
         ));
       case 'player':
-        var image = card['binding_values']['player_image']?['image_value'];
+        var image = card['binding_values']['player_image$imageKey']?['image_value'];
 
         return _createCard(card, Row(
           children: [

--- a/lib/tweet/_card.dart
+++ b/lib/tweet/_card.dart
@@ -38,18 +38,26 @@ class TweetCard extends StatelessWidget {
     );
   }
 
-  _createImage(Map<String, dynamic>? image, BoxFit fit, { double? aspectRatio }) {
+  _createImage(String size, Map<String, dynamic>? image, BoxFit fit, { double? aspectRatio }) {
     if (image == null) {
       return Container();
     }
 
-    return AspectRatio(
-      aspectRatio: aspectRatio ?? image['width'] / image['height'],
-      child: ExtendedImage.network(
+    Widget child;
+
+    if (size == 'disabled') {
+      child = Container();
+    } else {
+      child = ExtendedImage.network(
         image['url'],
         cache: true,
         fit: fit,
-      ),
+      );
+    }
+
+    return AspectRatio(
+      aspectRatio: aspectRatio ?? image['width'] / image['height'],
+      child: child,
     );
   }
 
@@ -197,7 +205,8 @@ class TweetCard extends StatelessWidget {
 
         return _createCard(card, Row(
           children: [
-            Expanded(flex: 1, child: _createImage(image, BoxFit.contain)),
+            if (imageSize != 'disabled')
+              Expanded(flex: 1, child: _createImage(imageSize, image, BoxFit.contain)),
             Expanded(flex: 4, child: _createListTile(context, card))
           ],
         ));
@@ -208,7 +217,8 @@ class TweetCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            _createImage(image, BoxFit.contain),
+            if (imageSize != 'disabled')
+              _createImage(imageSize, image, BoxFit.contain),
             Container(
               padding: EdgeInsets.symmetric(horizontal: 0, vertical: 10),
               child: _createListTile(context, card),
@@ -220,7 +230,7 @@ class TweetCard extends StatelessWidget {
 
         return _createCard(card, Row(
           children: [
-            Expanded(flex: 1, child: _createImage(image, BoxFit.cover, aspectRatio: 1)),
+            Expanded(flex: 1, child: _createImage(imageSize, image, BoxFit.cover, aspectRatio: 1)),
             Expanded(flex: 4, child: _createListTile(context, card))
           ],
         ));


### PR DESCRIPTION
This adds support for a new "Media size" option, containing multiple media sizes and an option to disable media. If media is disabled, a placeholder container is shown with a "tap to download" option.

This fixes #30.

<p style="float: left">
  <img src="https://user-images.githubusercontent.com/456645/118060585-fa3b9680-b38a-11eb-86a0-d2847c36a52b.jpg" width="350" />
  <img src="https://user-images.githubusercontent.com/456645/118060587-fad42d00-b38a-11eb-9c79-3696e8564763.jpg" width="350" />
  <img src="https://user-images.githubusercontent.com/456645/118060588-fad42d00-b38a-11eb-8f2d-74d610d5f38c.jpg" width="350" />
</p>