### PR TITLE
Add support for selecting a trend location

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/next.txt
+++ b/fastlane/metadata/android/en-US/changelogs/next.txt
@@ -1,3 +1,4 @@
+* Added support for selecting a location for trends
 * Added support for selecting the default tab when the app opens
 * Added support for selecting the media size
 * Now showing who a tweet is in reply to

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -9,3 +9,5 @@ const OPTION_SUBSCRIPTION_ORDER_BY_FIELD = 'subscription.order_by.field';
 
 const OPTION_THEME_MODE = 'theme.mode';
 const OPTION_THEME_TRUE_BLACK = 'theme.true_black';
+
+const OPTION_TRENDS_LOCATION = 'trends.location';

--- a/lib/home/_trends.dart
+++ b/lib/home/_trends.dart
@@ -1,70 +1,176 @@
 import 'package:dart_twitter_api/twitter_api.dart';
 import 'package:flutter/material.dart';
+import 'package:fritter/client.dart';
 import 'package:fritter/home/_search.dart';
 import 'package:fritter/home_model.dart';
+import 'package:fritter/ui/futures.dart';
 import 'package:intl/intl.dart';
+import 'package:pref/pref.dart';
 import 'package:provider/provider.dart';
 
-class TrendsContent extends StatelessWidget {
+class TrendsSettings extends StatefulWidget {
+  const TrendsSettings({Key? key}) : super(key: key);
+
+  @override
+  _TrendsSettingsState createState() => _TrendsSettingsState();
+}
+
+class _TrendsSettingsState extends State<TrendsSettings> {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Consumer<HomeModel>(
-        builder: (context, model, child) {
-          return FutureBuilder<List<Trends>>(
-            future: model.loadTrends(),
-            builder: (context, snapshot) {
-              var data = snapshot.data;
-              if (data == null) {
-                return Center(child: CircularProgressIndicator());
-              }
+    var prefs = PrefService.of(context);
+    var model = context.read<HomeModel>();
 
-              var trends = data[0].trends;
-              if (trends == null) {
-                return Text('There were no trends returned. This is unexpected! Please report as a bug, if possible.');
-              }
+    return FutureBuilder<List<TrendLocation>>(
+      future: Twitter.getTrendLocations(),
+      builder: (context, snapshot) {
+        var data = snapshot.data;
+        if (data == null) {
+          return Center(child: CircularProgressIndicator());
+        }
 
-              var numberFormat = NumberFormat.compact();
+        data.sort((a, b) => a.name!.compareTo(b.name!));
 
-              return ListView(
+        int _selected = prefs.get('trends.location.id');
+
+        return StatefulBuilder(builder: (context, setState) {
+          return AlertDialog(
+            content: Container(
+              width: double.maxFinite,
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: data.length,
+                itemBuilder: (context, index) {
+                  var item = data[index];
+
+                  return RadioListTile<int?>(
+                      title: Text(item.name!),
+                      subtitle: Text(item.country!),
+                      value: item.woeid,
+                      selected: _selected == item.woeid,
+                      groupValue: _selected,
+                      onChanged: (value) async {
+                        setState(() {
+                          _selected = item.woeid!;
+                        });
+
+                        await model.setTrendLocation(prefs, item);
+                      }
+                  );
+                },
+              ),
+            ),
+          );
+        });
+      },
+    );
+  }
+}
+
+class TrendsThing extends StatefulWidget {
+  final int id;
+
+  const TrendsThing({Key? key, required this.id}) : super(key: key);
+
+  @override
+  _TrendsThingState createState() => _TrendsThingState();
+}
+
+class _TrendsThingState extends State<TrendsThing> {
+  @override
+  Widget build(BuildContext context) {
+    var model = context.read<HomeModel>();
+    var prefs = PrefService.of(context);
+    var place = prefs.get('trends.location.name') ?? 'Worldwide';
+
+    return Column(
+      children: [
+        Container(
+          child: ListTile(
+              title: Text('$place trends', style: TextStyle(
+                  fontWeight: FontWeight.bold
+              )),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  Container(
-                    child: ListTile(
-                      title: Text('Worldwide trends', style: TextStyle(
-                          fontWeight: FontWeight.bold
-                      )),
-                    ),
-                  ),
-                  ListView.builder(
-                    shrinkWrap: true,
-                    physics: ScrollPhysics(),
-                    itemCount: trends.length,
-                    itemBuilder: (context, index) {
-                      var trend = trends[index];
-
-                      return ListTile(
-                        dense: true,
-                        leading: Text('${++index}'),
-                        title: Text('${trend.name!}'),
-                        subtitle: trend.tweetVolume == null
-                            ? null
-                            : Text('${numberFormat.format(trend.tweetVolume)} tweets'),
-                        onTap: () async {
-                          await showSearch(
-                              context: context,
-                              delegate: TweetSearchDelegate(
-                                initialTab: 1
-                              ),
-                              query: Uri.decodeQueryComponent(trend.query!)
-                          );
-                        },
-                      );
-                    },
+                  IconButton(
+                    icon: Icon(Icons.settings),
+                    onPressed: () async => showDialog(context: context, builder: (context) {
+                      return TrendsSettings();
+                    }),
                   )
                 ],
-              );
-            },
-          );
+              )
+          ),
+        ),
+        FutureBuilderWrapper<List<Trends>>(
+          future: model.loadTrends(widget.id),
+          onError: (error, stackTrace) {
+            return Center(
+              child: Text('$error'),
+            );
+          },
+          onReady: (data) {
+            var trends = data![0].trends;
+            if (trends == null) {
+              return Text('There were no trends returned. This is unexpected! Please report as a bug, if possible.');
+            }
+
+            var numberFormat = NumberFormat.compact();
+
+            return ListView.builder(
+              shrinkWrap: true,
+              physics: ScrollPhysics(),
+              itemCount: trends.length,
+              itemBuilder: (context, index) {
+                var trend = trends[index];
+
+                return ListTile(
+                  dense: true,
+                  leading: Text('${++index}'),
+                  title: Text('${trend.name!}'),
+                  subtitle: trend.tweetVolume == null
+                      ? null
+                      : Text('${numberFormat.format(trend.tweetVolume)} tweets'),
+                  onTap: () async {
+                    await showSearch(
+                        context: context,
+                        delegate: TweetSearchDelegate(
+                            initialTab: 1
+                        ),
+                        query: Uri.decodeQueryComponent(trend.query!)
+                    );
+                  },
+                );
+              },
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class TrendsContent extends StatefulWidget {
+  @override
+  _TrendsContentState createState() => _TrendsContentState();
+}
+
+class _TrendsContentState extends State<TrendsContent> {
+  @override
+  Widget build(BuildContext context) {
+    var prefs = PrefService.of(context);
+
+    return SingleChildScrollView(
+      child: StreamBuilder<int>(
+        stream: prefs.stream('trends.location.id'),
+        builder: (context, snapshot) {
+          switch (snapshot.connectionState) {
+            case ConnectionState.active:
+              return TrendsThing(id: snapshot.data ?? 1);
+            default:
+              return Center(child: CircularProgressIndicator());
+          }
         },
       ),
     );

--- a/lib/home/_trends.dart
+++ b/lib/home/_trends.dart
@@ -24,44 +24,48 @@ class _TrendsSettingsState extends State<TrendsSettings> {
     var prefs = PrefService.of(context);
     var model = context.read<HomeModel>();
 
-    return FutureBuilder<List<TrendLocation>>(
-      future: Twitter.getTrendLocations(),
-      builder: (context, snapshot) {
-        var data = snapshot.data;
-        if (data == null) {
-          return Center(child: CircularProgressIndicator());
-        }
+    return FutureBuilderWrapper<List<TrendLocation>>(
+        future: Twitter.getTrendLocations(),
+        onError: (error, stackTrace) {
+          return Center(
+            child: Text('$error'),
+          );
+        },
+        onReady: (data) {
+          if (data == null) {
+            return Text('There were no trend locations returned. This is unexpected! Please report as a bug, if possible.');
+          }
 
-        data.sort((a, b) => a.name!.compareTo(b.name!));
+          data.sort((a, b) => a.name!.compareTo(b.name!));
 
-        var place = TrendLocation.fromJson(jsonDecode(prefs.get(OPTION_TRENDS_LOCATION)));
+          var place = TrendLocation.fromJson(jsonDecode(prefs.get(OPTION_TRENDS_LOCATION)));
 
-        return AlertDialog(
-          content: Container(
-            width: double.maxFinite,
-            child: ListView.builder(
-              shrinkWrap: true,
-              itemCount: data.length,
-              itemBuilder: (context, index) {
-                var item = data[index];
+          return AlertDialog(
+            content: Container(
+              width: double.maxFinite,
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: data.length,
+                itemBuilder: (context, index) {
+                  var item = data[index];
 
-                return RadioListTile<int?>(
-                    title: Text(item.name!),
-                    subtitle: Text(item.country!),
-                    value: item.woeid,
-                    selected: place.woeid == item.woeid,
-                    groupValue: place.woeid,
-                    onChanged: (value) async {
-                      await model.setTrendLocation(prefs, item);
+                  return RadioListTile<int?>(
+                      title: Text(item.name!),
+                      subtitle: Text(item.country!),
+                      value: item.woeid,
+                      selected: place.woeid == item.woeid,
+                      groupValue: place.woeid,
+                      onChanged: (value) async {
+                        await model.setTrendLocation(prefs, item);
 
-                      Navigator.pop(context);
-                    }
-                );
-              },
+                        Navigator.pop(context);
+                      }
+                  );
+                },
+              ),
             ),
-          ),
-        );
-      },
+          );
+        }
     );
   }
 }

--- a/lib/home/_trends.dart
+++ b/lib/home/_trends.dart
@@ -1,6 +1,9 @@
+import 'dart:convert';
+
 import 'package:dart_twitter_api/twitter_api.dart';
 import 'package:flutter/material.dart';
 import 'package:fritter/client.dart';
+import 'package:fritter/constants.dart';
 import 'package:fritter/home/_search.dart';
 import 'package:fritter/home_model.dart';
 import 'package:fritter/ui/futures.dart';
@@ -31,122 +34,34 @@ class _TrendsSettingsState extends State<TrendsSettings> {
 
         data.sort((a, b) => a.name!.compareTo(b.name!));
 
-        int _selected = prefs.get('trends.location.id');
+        var place = TrendLocation.fromJson(jsonDecode(prefs.get(OPTION_TRENDS_LOCATION)));
 
-        return StatefulBuilder(builder: (context, setState) {
-          return AlertDialog(
-            content: Container(
-              width: double.maxFinite,
-              child: ListView.builder(
-                shrinkWrap: true,
-                itemCount: data.length,
-                itemBuilder: (context, index) {
-                  var item = data[index];
-
-                  return RadioListTile<int?>(
-                      title: Text(item.name!),
-                      subtitle: Text(item.country!),
-                      value: item.woeid,
-                      selected: _selected == item.woeid,
-                      groupValue: _selected,
-                      onChanged: (value) async {
-                        setState(() {
-                          _selected = item.woeid!;
-                        });
-
-                        await model.setTrendLocation(prefs, item);
-                      }
-                  );
-                },
-              ),
-            ),
-          );
-        });
-      },
-    );
-  }
-}
-
-class TrendsThing extends StatefulWidget {
-  final int id;
-
-  const TrendsThing({Key? key, required this.id}) : super(key: key);
-
-  @override
-  _TrendsThingState createState() => _TrendsThingState();
-}
-
-class _TrendsThingState extends State<TrendsThing> {
-  @override
-  Widget build(BuildContext context) {
-    var model = context.read<HomeModel>();
-    var prefs = PrefService.of(context);
-    var place = prefs.get('trends.location.name') ?? 'Worldwide';
-
-    return Column(
-      children: [
-        Container(
-          child: ListTile(
-              title: Text('$place trends', style: TextStyle(
-                  fontWeight: FontWeight.bold
-              )),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    icon: Icon(Icons.settings),
-                    onPressed: () async => showDialog(context: context, builder: (context) {
-                      return TrendsSettings();
-                    }),
-                  )
-                ],
-              )
-          ),
-        ),
-        FutureBuilderWrapper<List<Trends>>(
-          future: model.loadTrends(widget.id),
-          onError: (error, stackTrace) {
-            return Center(
-              child: Text('$error'),
-            );
-          },
-          onReady: (data) {
-            var trends = data![0].trends;
-            if (trends == null) {
-              return Text('There were no trends returned. This is unexpected! Please report as a bug, if possible.');
-            }
-
-            var numberFormat = NumberFormat.compact();
-
-            return ListView.builder(
+        return AlertDialog(
+          content: Container(
+            width: double.maxFinite,
+            child: ListView.builder(
               shrinkWrap: true,
-              physics: ScrollPhysics(),
-              itemCount: trends.length,
+              itemCount: data.length,
               itemBuilder: (context, index) {
-                var trend = trends[index];
+                var item = data[index];
 
-                return ListTile(
-                  dense: true,
-                  leading: Text('${++index}'),
-                  title: Text('${trend.name!}'),
-                  subtitle: trend.tweetVolume == null
-                      ? null
-                      : Text('${numberFormat.format(trend.tweetVolume)} tweets'),
-                  onTap: () async {
-                    await showSearch(
-                        context: context,
-                        delegate: TweetSearchDelegate(
-                            initialTab: 1
-                        ),
-                        query: Uri.decodeQueryComponent(trend.query!)
-                    );
-                  },
+                return RadioListTile<int?>(
+                    title: Text(item.name!),
+                    subtitle: Text(item.country!),
+                    value: item.woeid,
+                    selected: place.woeid == item.woeid,
+                    groupValue: place.woeid,
+                    onChanged: (value) async {
+                      await model.setTrendLocation(prefs, item);
+
+                      Navigator.pop(context);
+                    }
                 );
               },
-            );
-          },
-        ),
-      ],
+            ),
+          ),
+        );
+      },
     );
   }
 }
@@ -159,15 +74,82 @@ class TrendsContent extends StatefulWidget {
 class _TrendsContentState extends State<TrendsContent> {
   @override
   Widget build(BuildContext context) {
+    var model = context.read<HomeModel>();
     var prefs = PrefService.of(context);
 
     return SingleChildScrollView(
-      child: StreamBuilder<int>(
-        stream: prefs.stream('trends.location.id'),
+      child: StreamBuilder<String>(
+        stream: prefs.stream(OPTION_TRENDS_LOCATION),
         builder: (context, snapshot) {
           switch (snapshot.connectionState) {
             case ConnectionState.active:
-              return TrendsThing(id: snapshot.data ?? 1);
+              var place = TrendLocation.fromJson(jsonDecode(snapshot.data!));
+
+              return Column(
+                children: [
+                  Container(
+                    child: ListTile(
+                        title: Text('${place.name} trends', style: TextStyle(
+                            fontWeight: FontWeight.bold
+                        )),
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            IconButton(
+                              icon: Icon(Icons.settings),
+                              onPressed: () async => showDialog(context: context, builder: (context) {
+                                return TrendsSettings();
+                              }),
+                            )
+                          ],
+                        )
+                    ),
+                  ),
+                  FutureBuilderWrapper<List<Trends>>(
+                    future: model.loadTrends(place.woeid!),
+                    onError: (error, stackTrace) {
+                      return Center(
+                        child: Text('$error'),
+                      );
+                    },
+                    onReady: (data) {
+                      var trends = data![0].trends;
+                      if (trends == null) {
+                        return Text('There were no trends returned. This is unexpected! Please report as a bug, if possible.');
+                      }
+
+                      var numberFormat = NumberFormat.compact();
+
+                      return ListView.builder(
+                        shrinkWrap: true,
+                        physics: ScrollPhysics(),
+                        itemCount: trends.length,
+                        itemBuilder: (context, index) {
+                          var trend = trends[index];
+
+                          return ListTile(
+                            dense: true,
+                            leading: Text('${++index}'),
+                            title: Text('${trend.name!}'),
+                            subtitle: trend.tweetVolume == null
+                                ? null
+                                : Text('${numberFormat.format(trend.tweetVolume)} tweets'),
+                            onTap: () async {
+                              await showSearch(
+                                  context: context,
+                                  delegate: TweetSearchDelegate(
+                                      initialTab: 1
+                                  ),
+                                  query: Uri.decodeQueryComponent(trend.query!)
+                              );
+                            },
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ],
+              );
             default:
               return Center(child: CircularProgressIndicator());
           }

--- a/lib/home/_trends.dart
+++ b/lib/home/_trends.dart
@@ -7,6 +7,7 @@ import 'package:fritter/constants.dart';
 import 'package:fritter/home/_search.dart';
 import 'package:fritter/home_model.dart';
 import 'package:fritter/ui/futures.dart';
+import 'package:fritter/utils/iterables.dart';
 import 'package:intl/intl.dart';
 import 'package:pref/pref.dart';
 import 'package:provider/provider.dart';
@@ -40,29 +41,56 @@ class _TrendsSettingsState extends State<TrendsSettings> {
 
           var place = TrendLocation.fromJson(jsonDecode(prefs.get(OPTION_TRENDS_LOCATION)));
 
+          var countries = data
+              .sorted((a, b) => a.name!.compareTo(b.name!))
+              .groupBy((e) => e.country);
+
+          var names = countries.keys
+              .sorted((a, b) => a!.compareTo(b!))
+              .toList();
+
+          var _createLocationTile = (TrendLocation item) {
+            var subtitle = item.parentid == 1
+              ? Text('Country')
+              : null;
+
+            return RadioListTile<int?>(
+                title: Text(item.name!),
+                subtitle: subtitle,
+                value: item.woeid,
+                selected: place.woeid == item.woeid,
+                groupValue: place.woeid,
+                onChanged: (value) async {
+                  await model.setTrendLocation(prefs, item);
+
+                  Navigator.pop(context);
+                }
+            );
+          };
+
           return AlertDialog(
             content: Container(
               width: double.maxFinite,
               child: ListView.builder(
-                shrinkWrap: true,
-                itemCount: data.length,
+                itemCount: countries.length,
                 itemBuilder: (context, index) {
-                  var item = data[index];
+                  var name = names[index]!;
+                  if (name == '') {
+                    // If there's no country name, assume it's "Worldwide"
+                    return _createLocationTile(TrendLocation.fromJson({
+                      'name': 'Worldwide',
+                      'woeid': 1
+                    }));
+                  }
 
-                  return RadioListTile<int?>(
-                      title: Text(item.name!),
-                      subtitle: Text(item.country!),
-                      value: item.woeid,
-                      selected: place.woeid == item.woeid,
-                      groupValue: place.woeid,
-                      onChanged: (value) async {
-                        await model.setTrendLocation(prefs, item);
-
-                        Navigator.pop(context);
-                      }
+                  return ExpansionTile(
+                    title: Text(name),
+                    children: [
+                      ...countries[name]!.map((item) => _createLocationTile(item))
+                    ],
                   );
                 },
-              ),
+              )
             ),
           );
         }

--- a/lib/home_model.dart
+++ b/lib/home_model.dart
@@ -4,6 +4,7 @@ import 'dart:developer';
 import 'package:dart_twitter_api/twitter_api.dart';
 import 'package:flutter/material.dart';
 import 'package:fritter/client.dart';
+import 'package:fritter/constants.dart';
 import 'package:pref/pref.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
@@ -181,8 +182,7 @@ class HomeModel extends ChangeNotifier {
   }
 
   Future setTrendLocation(BasePrefService prefs, TrendLocation item) async {
-    prefs.set('trends.location.id', item.woeid);
-    prefs.set('trends.location.name', item.name);
+    prefs.set(OPTION_TRENDS_LOCATION, jsonEncode(item.toJson()));
 
     notifyListeners();
   }

--- a/lib/home_model.dart
+++ b/lib/home_model.dart
@@ -4,6 +4,7 @@ import 'dart:developer';
 import 'package:dart_twitter_api/twitter_api.dart';
 import 'package:flutter/material.dart';
 import 'package:fritter/client.dart';
+import 'package:pref/pref.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
 
@@ -57,8 +58,8 @@ class HomeModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<List<Trends>> loadTrends() async {
-    return Twitter.getTrends();
+  Future<List<Trends>> loadTrends(int location) async {
+    return Twitter.getTrends(location);
   }
 
   Future<List<SubscriptionGroup>> listSubscriptionGroups() async {
@@ -177,5 +178,12 @@ class HomeModel extends ChangeNotifier {
     }
 
     await batch.commit();
+  }
+
+  Future setTrendLocation(BasePrefService prefs, TrendLocation item) async {
+    prefs.set('trends.location.id', item.woeid);
+    prefs.set('trends.location.name', item.name);
+
+    notifyListeners();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -95,7 +95,11 @@ Future<void> main() async {
   final prefService = await PrefServiceShared.init(prefix: 'pref_', defaults: {
     OPTION_MEDIA_SIZE: 'medium',
     OPTION_THEME_MODE: 'system',
-    OPTION_THEME_TRUE_BLACK: false
+    OPTION_THEME_TRUE_BLACK: false,
+    OPTION_TRENDS_LOCATION: jsonEncode({
+      'name': 'Worldwide',
+      'woeid': 1
+    }),
   });
 
   runApp(PrefService(

--- a/lib/ui/futures.dart
+++ b/lib/ui/futures.dart
@@ -1,0 +1,37 @@
+import 'dart:developer';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class FutureBuilderWrapper<T> extends StatelessWidget {
+  final Future<T>? future;
+  final Widget Function(Object? error, StackTrace? stackTrace) onError;
+  final Widget Function(T? data) onReady;
+
+  const FutureBuilderWrapper({Key? key, required this.future, required this.onError, required this.onReady}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<T>(
+      future: future,
+      builder: (context, snapshot) {
+        var state = snapshot.connectionState;
+
+        switch (state) {
+          case ConnectionState.waiting:
+            return Center(child: CircularProgressIndicator());
+          case ConnectionState.done:
+            if (snapshot.hasError) {
+              log('An error occurred', error: snapshot.error, stackTrace: snapshot.stackTrace);
+
+              return onError(snapshot.error, snapshot.stackTrace);
+            }
+
+            return onReady(snapshot.data);
+          default:
+            return Center(child: Text('The connection state $state is not supported'));
+        }
+      },
+    );
+  }
+}

--- a/lib/utils/cache.dart
+++ b/lib/utils/cache.dart
@@ -1,0 +1,22 @@
+import 'dart:developer';
+
+import 'package:ffcache/ffcache.dart';
+
+extension CacheHelper<T> on FFCache {
+  Future<String> getOrCreateAsJSON(String key, Duration expiry, Future<String> Function() create) async {
+    var exists = await has(key);
+    if (exists) {
+      log('Loading $key from the cache');
+
+      return await getJSON(key);
+    }
+
+    log('Loading $key from the source');
+
+    var result = await create();
+
+    await setJSONWithTimeout(key, result, expiry);
+
+    return result;
+  }
+}

--- a/lib/utils/iterables.dart
+++ b/lib/utils/iterables.dart
@@ -1,0 +1,10 @@
+extension Iterables<E> on Iterable<E> {
+  Map<K, List<E>> groupBy<K>(K Function(E) keyFunction) => fold(
+      <K, List<E>>{},
+          (Map<K, List<E>> map, E element) =>
+      map..putIfAbsent(keyFunction(element), () => <E>[]).add(element));
+}
+
+extension ListSorted<T> on Iterable<T> {
+  Iterable<T> sorted(int compare(T a, T b)) => [...this]..sort(compare);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0-rc.2"
+  ffcache:
+    dependency: "direct main"
+    description:
+      name: ffcache
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   ffi:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   dotted_border: ^2.0.0-nullsafety.0
   extended_image: ^4.0.1
   faker: ^2.0.0-rc.2
+  ffcache: ^1.0.0
   flex_color_scheme: ^2.1.1
   file_picker_writable:
     git:


### PR DESCRIPTION
This adds support for being able to select a location for the trends screen. It defaults to Worldwide, and the user can select from all the locations Twitter exposes in their API.

This fixes #21.

<p style="float: left">
  <img src="https://user-images.githubusercontent.com/456645/118405427-c81e8300-b66f-11eb-8689-c6c9210de562.jpg" width="350" />
  <img src="https://user-images.githubusercontent.com/456645/118405429-c94fb000-b66f-11eb-9575-04b531aca051.jpg" width="350" />
</p>