### PR TITLE
Prefix media download filename with Twitter username

### DIFF
--- a/lib/tweet/_media.dart
+++ b/lib/tweet/_media.dart
@@ -107,8 +107,9 @@ class _TweetMediaItemState extends State<TweetMediaItem> {
 
 class TweetMedia extends StatefulWidget {
   final List<Media> media;
+  final String username;
 
-  const TweetMedia({Key? key, required this.media}) : super(key: key);
+  const TweetMedia({Key? key, required this.media, required this.username}) : super(key: key);
 
   @override
   _TweetMediaState createState() => _TweetMediaState();
@@ -135,7 +136,8 @@ class _TweetMediaState extends State<TweetMedia> {
             var item = widget.media[index];
 
             return GestureDetector(
-              onTap: () => Navigator.push(context, MaterialPageRoute(builder: (context) => TweetMediaView(initialIndex: index, media: widget.media))),
+              onTap: () => Navigator.push(context,
+                  MaterialPageRoute(builder: (context) => TweetMediaView(initialIndex: index, media: widget.media, username: widget.username ))),
               child: TweetMediaItem(media: item, index: index + 1, total: widget.media.length),
             );
           },
@@ -148,8 +150,9 @@ class _TweetMediaState extends State<TweetMedia> {
 class TweetMediaView extends StatefulWidget {
   final int initialIndex;
   final List<Media> media;
+  final String username;
 
-  const TweetMediaView({Key? key, required this.initialIndex, required this.media}) : super(key: key);
+  const TweetMediaView({Key? key, required this.initialIndex, required this.media, required this.username}) : super(key: key);
 
   @override
   _TweetMediaViewState createState() => _TweetMediaViewState();
@@ -159,12 +162,14 @@ class _TweetMediaViewState extends State<TweetMediaView> {
   static final log = Logger('_TweetMediaViewState');
 
   late Media _media;
+  late String _username;
 
   @override
   void initState() {
     super.initState();
 
     this._media = widget.media[widget.initialIndex];
+    this._username = widget.username;
   }
 
   @override
@@ -181,7 +186,8 @@ class _TweetMediaViewState extends State<TweetMediaView> {
           IconButton(
             icon: Icon(Icons.file_download),
             onPressed: () async {
-              var fileName = path.basename(_media.mediaUrlHttps!);
+              var url = path.basename(_media.mediaUrlHttps!);
+              var fileName = '$_username-$url';
               var uri = '${_media.mediaUrlHttps}:orig';
 
               await downloadUriToPickedFile(uri, fileName,

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -76,7 +76,7 @@ class TweetTile extends StatelessWidget {
 
     Widget media = Container();
     if (tweet.extendedEntities?.media != null && tweet.extendedEntities!.media!.isNotEmpty) {
-      media = TweetMedia(media: tweet.extendedEntities!.media!);
+      media = TweetMedia(media: tweet.extendedEntities!.media!, username: this.tweet!.user!.name!);
     }
 
     Widget retweetBanner = Container();

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -76,7 +76,7 @@ class TweetTile extends StatelessWidget {
 
     Widget media = Container();
     if (tweet.extendedEntities?.media != null && tweet.extendedEntities!.media!.isNotEmpty) {
-      media = TweetMedia(media: tweet.extendedEntities!.media!, username: this.tweet!.user!.name!);
+      media = TweetMedia(media: tweet.extendedEntities!.media!, username: this.tweet!.user!.screenName!);
     }
 
     Widget retweetBanner = Container();


### PR DESCRIPTION
This patch makes it so when downloading tweet media the Twitter handle of the tweet is prepended to the initial filename.

I've built+tested this and it is working on Android 11.