### PR TITLE
Fixed Data exported toast when nothing has been exported (#213)

### DIFF
--- a/lib/settings/settings_export_screen.dart
+++ b/lib/settings/settings_export_screen.dart
@@ -136,13 +136,14 @@ class _SettingsExportScreenState extends State<SettingsExportScreen> {
             var fileName = 'fritter-${dateFormat.format(DateTime.now())}.json';
 
             // This platform can support the directory picker, so display it
-            await FilePickerWritable().openFileForCreate(fileName: fileName, writer: (file) async {
+            var fileInfo = await FilePickerWritable().openFileForCreate(fileName: fileName, writer: (file) async {
               file.writeAsStringSync(exportData);
             });
-
-            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-              content: Text('Data exported to $fileName'),
-            ));
+            if (fileInfo != null) {
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                content: Text('Data exported to $fileName'),
+              ));
+            }
           }
         },
       ),


### PR DESCRIPTION
Hi,

I've fixed a bug with "Data exported" toast that was described in the issue #213.

**Before:**
![poz1ccFvRV](https://user-images.githubusercontent.com/85929121/131027629-ffb8a4b4-116a-43aa-908c-2fbdc396e7b0.gif)

**After:**
![ynQ4BHjs8a](https://user-images.githubusercontent.com/85929121/131027743-c9376016-b24a-4e64-854a-e56aae95e8fa.gif)
