### PR TITLE
User preferences: add a toggle to disable update check #331

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -2,6 +2,8 @@ const optionErrorsSentryEnabled = 'errors.sentry_enabled';
 
 const optionHelloLastBuild = 'hello.last_build';
 
+const optionShouldCheckForUpdates = 'should_check_for_updates';
+
 const optionHomeInitialTab = 'home.initial_tab';
 
 const optionMediaSize = 'media.size';

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -2045,6 +2045,26 @@ class L10n {
       args: [],
     );
   }
+
+  /// `Check for updates`
+  String get should_check_for_updates_label {
+    return Intl.message(
+      'Check for updates',
+      name: 'should_check_for_updates_label',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Enable to check for updates when Fritter starts`
+  String get should_check_for_updates_description {
+    return Intl.message(
+      'Enable to check for updates when Fritter starts',
+      name: 'should_check_for_updates_description',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -193,5 +193,7 @@
     "fritter_blue": "Fritter blue",
     "blue_theme_based_on_the_twitter_color_scheme": "Blue theme based on the Twitter color scheme",
     "something_broke_in_fritter": "Something broke in Fritter.",
-    "unable_to_run_the_database_migrations": "Unable to run the database migrations"
+    "unable_to_run_the_database_migrations": "Unable to run the database migrations",
+    "should_check_for_updates_label": "Check for updates",
+    "should_check_for_updates_description": "Enable to check for updates when Fritter starts"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,7 +39,6 @@ import 'package:fritter/generated/l10n.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
 Future checkForUpdates() async {
-  L10n.load(const Locale('en'));
   Logger.root.info('Checking for updates');
 
   try {
@@ -49,10 +48,6 @@ Future checkForUpdates() async {
       var result = jsonDecode(response.body);
 
       var flavor = getFlavor();
-      if (flavor == 'play') {
-        // Don't check for updates for the Play Store build
-        return;
-      }
 
       var release = result['versions'][flavor]['stable'];
       var latest = release['versionCode'];
@@ -132,7 +127,10 @@ Future<void> main() async {
 
   setTimeagoLocales();
 
+  L10n.load(const Locale('en'));
+
   final prefService = await PrefServiceShared.init(prefix: 'pref_', defaults: {
+    optionShouldCheckForUpdates: true,
     optionMediaSize: 'medium',
     optionSubscriptionGroupsOrderByAscending: false,
     optionSubscriptionGroupsOrderByField: 'name',
@@ -189,7 +187,12 @@ Future<void> main() async {
             }
           });
 
-          checkForUpdates();
+          var flavor = getFlavor();
+          var shouldCheckForUpdates = prefService.get(optionShouldCheckForUpdates);
+          if (flavor != 'play' && shouldCheckForUpdates) {
+            // Don't check for updates for the Play Store build or if user disabled it.
+            checkForUpdates();
+          }
         }
 
         // Run the migrations early, so models work. We also do this later on so we can display errors to the user
@@ -231,6 +234,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   static final log = Logger('_MyAppState');
 
+  bool _shouldCheckForUpdates = true;
   String _themeMode = 'system';
   bool _trueBlack = false;
 
@@ -242,8 +246,15 @@ class _MyAppState extends State<MyApp> {
 
     // Set any already-enabled preferences
     setState(() {
+      _shouldCheckForUpdates = prefService.get(optionShouldCheckForUpdates);
       _themeMode = prefService.get(optionThemeMode) ?? 'system';
       _trueBlack = prefService.get(optionThemeTrueBlack) ?? false;
+    });
+
+    prefService.addKeyListener(optionShouldCheckForUpdates, () {
+      setState(() {
+        _shouldCheckForUpdates = prefService.get(optionShouldCheckForUpdates);
+      });
     });
 
     // Whenever the "true black" preference is toggled, apply the toggle

--- a/lib/settings/settings.dart
+++ b/lib/settings/settings.dart
@@ -256,6 +256,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               onTap: _sendPing,
             ),
+            if (getFlavor() != 'play')
+              PrefSwitch(
+                title: Text(L10n.of(context).should_check_for_updates_label),
+                pref: optionShouldCheckForUpdates,
+                subtitle:
+                    Text(L10n.of(context).should_check_for_updates_description),
+              ),
             PrefTitle(
               title: Text(L10n.of(context).general),
             ),


### PR DESCRIPTION
Add a new user setting to toggle update check at application startup.

This will be visible on non playstore app only.

This feature add two localized strings: `should_check_for_update_label` and `should_check_for_update_description`

Resolve issue #153 and #331 