### PR TITLE
Add basic regex filter

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -6,6 +6,7 @@ const optionHomeInitialTab = 'home.initial_tab';
 
 const optionMediaSize = 'media.size';
 
+const optionRegexFilter = 'regex_filter';
 const optionSubscriptionGroupsOrderByAscending = 'subscription_groups.order_by.ascending';
 const optionSubscriptionGroupsOrderByField = 'subscription_groups.order_by.field';
 const optionSubscriptionOrderByAscending = 'subscription.order_by.ascending';

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -234,6 +234,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "prefix": MessageLookupByLibrary.simpleMessage("prefix"),
         "private_profile":
             MessageLookupByLibrary.simpleMessage("Private profile"),
+        "regex_filter": MessageLookupByLibrary.simpleMessage("Filter tweets via regex"),
         "released_under_the_mit_license": MessageLookupByLibrary.simpleMessage(
             "Released under the MIT License"),
         "replying_to": MessageLookupByLibrary.simpleMessage("Replying to"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1741,6 +1741,16 @@ class L10n {
       args: [],
     );
   }
+  
+  /// `This tweet was filtered`
+  String get this_tweet_was_filtered {
+    return Intl.message(
+      'This tweet was filtered',
+      name: 'this_tweet_was_filtered',
+      desc: '',
+      args: [],
+    );
+  }
 
   /// `This tweet is unavailable`
   String get this_tweet_is_unavailable {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -193,5 +193,6 @@
     "fritter_blue": "Fritter blue",
     "blue_theme_based_on_the_twitter_color_scheme": "Blue theme based on the Twitter color scheme",
     "something_broke_in_fritter": "Something broke in Fritter.",
-    "unable_to_run_the_database_migrations": "Unable to run the database migrations"
+    "unable_to_run_the_database_migrations": "Unable to run the database migrations",
+    "regex_filter": "Filter tweets via regex"
 }

--- a/lib/settings/settings.dart
+++ b/lib/settings/settings.dart
@@ -296,11 +296,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     value: 'large',
                   ),
                 ]),
-            PrefText(
-                label: L10n.of(context).regex_filter,
-                pref: optionRegexFilter,
-                // TODO: Add regex validator
-                hintText: "ExampleFilter1|ExampleFilter[2-3]"),
             PrefTitle(title: Text(L10n.of(context).theme)),
             PrefDropdown(fullWidth: false, title: Text(L10n.of(context).theme), pref: optionThemeMode, items: [
               DropdownMenuItem(
@@ -413,6 +408,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
               subtitle: Text(L10n.of(context).export_your_data),
               onTap: () => Navigator.pushNamed(context, routeSettingsExport),
             ),
+            PrefTitle(title: Text(L10n.of(context).filters)),
+            PrefText(
+                label: L10n.of(context).regex_filter,
+                pref: optionRegexFilter,
+                // TODO: Add regex validator
+                hintText: "ExampleFilter1|ExampleFilter[2-3]"),
             PrefTitle(title: Text(L10n.of(context).logging)),
             PrefCheckbox(
               title: Text(L10n.of(context).enable_sentry),

--- a/lib/settings/settings.dart
+++ b/lib/settings/settings.dart
@@ -296,6 +296,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     value: 'large',
                   ),
                 ]),
+            PrefText(
+                label: L10n.of(context).regex_filter,
+                pref: optionRegexFilter,
+                // TODO: Add regex validator
+                hintText: "ExampleFilter1|ExampleFilter[2-3]"),
             PrefTitle(title: Text(L10n.of(context).theme)),
             PrefDropdown(fullWidth: false, title: Text(L10n.of(context).theme), pref: optionThemeMode, items: [
               DropdownMenuItem(

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -25,6 +25,7 @@ import 'package:provider/provider.dart';
 import 'package:share/share.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:url_launcher/url_launcher.dart';
+import 'package:pref/pref.dart';
 
 class TweetTile extends StatefulWidget {
   final bool clickable;
@@ -276,6 +277,25 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
     var numberFormat = NumberFormat.compact();
 
     TweetWithCard tweet = this.tweet.retweetedStatusWithCard == null ? this.tweet : this.tweet.retweetedStatusWithCard!;
+    
+    // Get filter string from options:
+    var prefService = PrefService.of(context);
+    var regexFilterString = prefService.get(optionRegexFilter);
+
+    if (regexFilterString != null && regexFilterString.isNotEmpty){
+      RegExp regexFilter = RegExp('$regexFilterString', caseSensitive: false, multiLine: true);
+     
+      // Check if regex filter matches tweet text:
+      if (regexFilter.hasMatch( tweet.fullText.toString() )) {
+        
+        // TODO: completely remove the card instead of showing "This tweet was filtered"
+        tweet.text = L10n.of(context).this_tweet_was_filtered;
+        tweet.fullText = L10n.of(context).this_tweet_was_filtered;
+        tweet.idStr = '';
+        tweet.isTombstone = true;
+        return const SizedBox.shrink(); // Empty widget
+      }
+    }
 
     if (tweet.isTombstone ?? false) {
       return SizedBox(


### PR DESCRIPTION
I added a filtering option as requested by #86, #148, #287
At the moment it doesn't hide the tweets completely, but instead shows a small card containing `This tweet was filtered`.
That is because I don't have any experience with Dart/Flutter or Android development in general. I just wanted to provide a minimal working example that can be improved by people who actually know what they're doing.

It works by adding the words you want to get filtered separated by `|` to the new Filters setting. It just converts the string into a regular expression so you can use expressions like `\W[a-z]{2,3}` and so on.

Example:  `bitcoin|nft|#sponsored|trump`

The filter is case insensitive and removes all tweets containing the regex, so if you don't want tweets with `trumpet` removed you need to use `trump\b` instead of `trump`. Since the string gets evaluated as regex you need to escape characters like dots or brackets if you want to use them in the filter.