### PR TITLE
Media: add video and gif autoplay options (#268)

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -7,6 +7,8 @@ const optionShouldCheckForUpdates = 'should_check_for_updates';
 const optionHomeInitialTab = 'home.initial_tab';
 
 const optionMediaSize = 'media.size';
+const optionMediaVideoAutoplay = 'media.video_autoplay';
+const optionMediaGifAutoplay = 'media.gif_autoplay';
 
 const optionDownloadType = 'download.type';
 const optionDownloadPath = 'download.path';

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -861,6 +861,26 @@ class L10n {
     );
   }
 
+  /// `Gif autoplay`
+  String get should_autoplay_gif {
+    return Intl.message(
+      'Gif autoplay',
+      name: 'should_autoplay_gif',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Video autoplay`
+  String get should_autoplay_video {
+    return Intl.message(
+      'Video autoplay',
+      name: 'should_autoplay_video',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Theme`
   String get theme {
     return Intl.message(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -171,6 +171,8 @@ Future<void> main() async {
     optionDownloadType: optionDownloadTypeAsk,
     optionLocale: optionLocaleDefault,
     optionMediaSize: 'medium',
+    optionMediaVideoAutoplay: false,
+    optionMediaGifAutoplay: false,
     optionShouldCheckForUpdates: true,
     optionSubscriptionGroupsOrderByAscending: false,
     optionSubscriptionGroupsOrderByField: 'name',

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -254,6 +254,14 @@ class SettingsGeneralFragment extends StatelessWidget with AppBarMixin {
                 child: Text(L10n.of(context).large),
               ),
             ]),
+        PrefSwitch(
+          title: Text(L10n.of(context).should_autoplay_video),
+          pref: optionMediaVideoAutoplay,
+        ),
+        PrefSwitch(
+          title: Text(L10n.of(context).should_autoplay_gif),
+          pref: optionMediaGifAutoplay,
+        ),
         const DownloadTypeSetting(),
         PrefCheckbox(
           title: Text(L10n.of(context).enable_sentry),

--- a/lib/tweet/_media.dart
+++ b/lib/tweet/_media.dart
@@ -62,6 +62,8 @@ class _TweetMediaItemState extends State<TweetMediaItem> {
   Widget build(BuildContext context) {
     var prefs = PrefService.of(context, listen: false);
     var size = prefs.get(optionMediaSize);
+    var videoAutoplay = prefs.get(optionMediaVideoAutoplay);
+    var gifAutoplay = prefs.get(optionMediaGifAutoplay);
     if (size == 'disabled') {
       size = 'medium';
     }
@@ -72,9 +74,9 @@ class _TweetMediaItemState extends State<TweetMediaItem> {
 
     if (_showMedia) {
       if (item.type == 'animated_gif') {
-        media = TweetVideo(media: item, loop: true);
+        media = TweetVideo(media: item, loop: true, autoplay: gifAutoplay);
       } else if (item.type == 'video') {
-        media = TweetVideo(media: item, loop: false);
+        media = TweetVideo(media: item, loop: false, autoplay: videoAutoplay);
       } else if (item.type == 'photo') {
         media = TweetPhoto(size: size, uri: item.mediaUrlHttps!);
       } else {
@@ -192,6 +194,8 @@ class _TweetMediaViewState extends State<TweetMediaView> {
   Widget build(BuildContext context) {
     var prefs = PrefService.of(context, listen: false);
     var size = prefs.get(optionMediaSize);
+    var videoAutoplay = prefs.get(optionMediaVideoAutoplay);
+    var gifAutoplay = prefs.get(optionMediaGifAutoplay);
     if (size == 'disabled') {
       size = 'medium';
     }
@@ -241,9 +245,9 @@ class _TweetMediaViewState extends State<TweetMediaView> {
 
           Widget media;
           if (item.type == 'animated_gif') {
-            media = TweetVideo(media: item, loop: true);
+            media = TweetVideo(media: item, loop: true, autoplay: gifAutoplay);
           } else if (item.type == 'video') {
-            media = TweetVideo(media: item, loop: false);
+            media = TweetVideo(media: item, loop: false, autoplay: videoAutoplay);
           } else if (item.type == 'photo') {
             media = TweetPhoto(size: size, uri: item.mediaUrlHttps!, fit: BoxFit.scaleDown);
           } else {

--- a/lib/tweet/_video.dart
+++ b/lib/tweet/_video.dart
@@ -12,9 +12,10 @@ import 'package:fritter/generated/l10n.dart';
 
 class TweetVideo extends StatefulWidget {
   final bool loop;
+  final bool autoplay;
   final Media media;
 
-  const TweetVideo({Key? key, required this.loop, required this.media}) : super(key: key);
+  const TweetVideo({Key? key, required this.loop, required this.autoplay, required this.media}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _TweetVideoState();
@@ -29,6 +30,9 @@ class _TweetVideoState extends State<TweetVideo> {
   @override
   void initState() {
     super.initState();
+    if (widget.autoplay) {
+      onTapPlay();
+    }
   }
 
   void _loadVideo() {
@@ -44,6 +48,7 @@ class _TweetVideoState extends State<TweetVideo> {
       aspectRatio: aspectRatio,
       autoInitialize: true,
       autoPlay: true,
+      showControls: widget.media.type != 'animated_gif',
       allowMuting: true,
       allowedScreenSleep: false,
       additionalOptions: (context) => [


### PR DESCRIPTION
Add two options to autoplay videos and animated GIFs image.

Resolving #268 

This PR need be considered as work in progress, as videos are played as soon as the the 'TweetVideo' object is instanced, before it's visible on the screen. 
This should be reworked to make the playback start when the media is in the center of the screen and stop when out of screen.