### PR TITLE
added "default muting" and "remember muting" option.

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -8,6 +8,7 @@ const optionHomePages = 'home.pages';
 const optionHomeInitialTab = 'home.initial_tab';
 
 const optionMediaSize = 'media.size';
+const optionsMediaDefaultMute = 'media.mute';
 
 const optionDownloadType = 'download.type';
 const optionDownloadPath = 'download.path';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ import 'package:fritter/status.dart';
 import 'package:fritter/subscriptions/_import.dart';
 import 'package:fritter/subscriptions/users_model.dart';
 import 'package:fritter/trends/trends_model.dart';
+import 'package:fritter/tweet/_video.dart';
 import 'package:fritter/ui/errors.dart';
 import 'package:fritter/utils/urls.dart';
 import 'package:http/http.dart' as http;
@@ -170,6 +171,7 @@ Future<void> main() async {
     optionHomePages: defaultHomePages.map((e) => e.id).toList(),
     optionLocale: optionLocaleDefault,
     optionMediaSize: 'medium',
+    optionsMediaDefaultMute: false,
     optionNonConfirmationBiasMode: false,
     optionShouldCheckForUpdates: true,
     optionSubscriptionGroupsOrderByAscending: false,
@@ -271,6 +273,8 @@ Future<void> main() async {
 
         var trendLocationModel = UserTrendLocationModel(prefService);
 
+        var videoMuteModel = VideoMuteModel(prefService);
+
         runApp(PrefService(
             service: prefService,
             child: MultiProvider(
@@ -285,6 +289,7 @@ Future<void> main() async {
                 Provider(create: (context) => trendLocationModel),
                 Provider(create: (context) => TrendLocationsModel()),
                 Provider(create: (context) => TrendsModel(trendLocationModel)),
+                Provider(create: (context) => videoMuteModel),
               ],
               child: DevicePreview(
                 enabled: !kReleaseMode,

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -224,7 +224,9 @@ class SettingsGeneralFragment extends StatelessWidget {
                 L10n.of(context).which_tab_is_shown_when_the_app_opens,
               ),
               pref: optionHomeInitialTab,
-              items: defaultHomePages.map((e) => DropdownMenuItem(value: e.id, child: Text(e.titleBuilder(context)))).toList()),
+              items: defaultHomePages
+                  .map((e) => DropdownMenuItem(value: e.id, child: Text(e.titleBuilder(context))))
+                  .toList()),
           PrefDropdown(
               fullWidth: false,
               title: Text(L10n.of(context).media_size),
@@ -254,6 +256,13 @@ class SettingsGeneralFragment extends StatelessWidget {
                   child: Text(L10n.of(context).large),
                 ),
               ]),
+
+          /// TODO: translate
+          PrefSwitch(
+            pref: optionsMediaDefaultMute,
+            title: Text('Mute videos'),
+            subtitle: Text('"Whether all videos should be muted"'),
+          ),
           PrefCheckbox(
             title: Text(L10n.of(context).hide_sensitive_tweets),
             subtitle: Text(L10n.of(context).whether_to_hide_tweets_marked_as_sensitive),


### PR DESCRIPTION
I added two more option to the general settings tab, addressing the media:

-  default muting: All videos will be muted by default

 - remember muting in feed: if the user mutes or enables the sound for one video in the feed, the decision will be remembered across the feed. 

Both options default to "false".
I find them very useful.
