### PR TITLE
FIX: Bug #521 title overlapping

### DIFF
--- a/lib/group/group_screen.dart
+++ b/lib/group/group_screen.dart
@@ -53,9 +53,7 @@ class SubscriptionGroupScreenContent extends StatelessWidget {
         }
 
         // Split the users into chunks, oldest first, to prevent thrashing of all groups when a new user is added
-        var users = group.subscriptions
-            .sorted((a, b) => a.createdAt.compareTo(b.createdAt))
-            .toList();
+        var users = group.subscriptions.sorted((a, b) => a.createdAt.compareTo(b.createdAt)).toList();
 
         var chunks = partition(users, 16)
             .map((e) => SubscriptionGroupFeedChunk(e, group.includeReplies, group.includeRetweets))
@@ -92,7 +90,9 @@ class SubscriptionGroupScreen extends StatelessWidget {
   final String name;
   final List<Widget> actions;
 
-  const SubscriptionGroupScreen({Key? key, required this.scrollController, required this.id, required this.name, required this.actions}) : super(key: key);
+  const SubscriptionGroupScreen(
+      {Key? key, required this.scrollController, required this.id, required this.name, required this.actions})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -115,17 +115,14 @@ class SubscriptionGroupScreen extends StatelessWidget {
                 pinned: false,
                 snap: true,
                 floating: true,
-                flexibleSpace: FlexibleSpaceBar(
-                  title: Text(name),
-                ),
+                title: Text(name.replaceFirst('Group: ', '')),
                 actions: [
-                  IconButton(
-                      icon: const Icon(Icons.more_vert),
-                      onPressed: () => showFeedSettings(context, model)),
+                  IconButton(icon: const Icon(Icons.more_vert), onPressed: () => showFeedSettings(context, model)),
                   IconButton(
                       icon: const Icon(Icons.arrow_upward),
                       onPressed: () async {
-                        await scrollController.animateTo(0, duration: const Duration(seconds: 1), curve: Curves.easeInOut);
+                        await scrollController.animateTo(0,
+                            duration: const Duration(seconds: 1), curve: Curves.easeInOut);
                       }),
                   IconButton(
                       icon: const Icon(Icons.refresh),

--- a/lib/home/_groups.dart
+++ b/lib/home/_groups.dart
@@ -13,43 +13,40 @@ class GroupsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: NestedScrollView(
-        controller: scrollController,
-        headerSliverBuilder: (context, innerBoxIsScrolled) {
-          return [
-            SliverAppBar(
-              pinned: false,
-              snap: true,
-              floating: true,
-              flexibleSpace: FlexibleSpaceBar(
-                title: Text(L10n.current.groups),
+        body: NestedScrollView(
+      controller: scrollController,
+      headerSliverBuilder: (context, innerBoxIsScrolled) {
+        return [
+          SliverAppBar(
+            pinned: false,
+            snap: true,
+            floating: true,
+            title: Text(L10n.current.groups),
+            actions: [
+              PopupMenuButton<String>(
+                icon: const Icon(Icons.sort),
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: 'name',
+                    child: Text(L10n.of(context).name),
+                  ),
+                  PopupMenuItem(
+                    value: 'created_at',
+                    child: Text(L10n.of(context).date_created),
+                  ),
+                ],
+                onSelected: (value) => context.read<GroupsModel>().changeOrderSubscriptionGroupsBy(value),
               ),
-              actions: [
-                PopupMenuButton<String>(
-                  icon: const Icon(Icons.sort),
-                  itemBuilder: (context) => [
-                    PopupMenuItem(
-                      value: 'name',
-                      child: Text(L10n.of(context).name),
-                    ),
-                    PopupMenuItem(
-                      value: 'created_at',
-                      child: Text(L10n.of(context).date_created),
-                    ),
-                  ],
-                  onSelected: (value) => context.read<GroupsModel>().changeOrderSubscriptionGroupsBy(value),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.sort_by_alpha),
-                  onPressed: () => context.read<GroupsModel>().toggleOrderSubscriptionGroupsAscending(),
-                ),
-                ...createCommonAppBarActions(context),
-              ],
-            )
-          ];
-        },
-        body: SubscriptionGroups(scrollController: scrollController),
-      )
-    );
+              IconButton(
+                icon: const Icon(Icons.sort_by_alpha),
+                onPressed: () => context.read<GroupsModel>().toggleOrderSubscriptionGroupsAscending(),
+              ),
+              ...createCommonAppBarActions(context),
+            ],
+          )
+        ];
+      },
+      body: SubscriptionGroups(scrollController: scrollController),
+    ));
   }
 }

--- a/lib/home/_saved.dart
+++ b/lib/home/_saved.dart
@@ -16,7 +16,7 @@ import 'package:provider/provider.dart';
 
 class SavedScreen extends StatefulWidget {
   final ScrollController scrollController;
-  
+
   const SavedScreen({Key? key, required this.scrollController}) : super(key: key);
 
   @override
@@ -43,9 +43,7 @@ class _SavedScreenState extends State<SavedScreen> {
             pinned: false,
             snap: true,
             floating: true,
-            flexibleSpace: FlexibleSpaceBar(
-              title: Text(L10n.current.saved),
-            ),
+            title: Text(L10n.current.saved),
             actions: createCommonAppBarActions(context),
           )
         ];


### PR DESCRIPTION
[#521] Replaced `flexibleSpace` property in `SliverAppBar` with the normal `title` property. All AppBars should now look the same. 
For the custom Group-Screens I removed the "Group: " caption from the name.