### PR TITLE
add navigation to profile of the person who retweeted [#518]

### DIFF
--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -310,9 +310,11 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
     if (this.tweet.retweetedStatusWithCard != null) {
       retweetBanner = _TweetTileLeading(
         icon: Icons.repeat,
+        onTap: () => Navigator.pushNamed(context, routeProfile, arguments: this.tweet.user!.screenName!),
         children: [
           TextSpan(
-              text: L10n.of(context).this_tweet_user_name_retweeted(this.tweet.user!.name!, createRelativeDate(this.tweet.createdAt!)),
+              text: L10n.of(context)
+                  .this_tweet_user_name_retweeted(this.tweet.user!.name!, createRelativeDate(this.tweet.createdAt!)),
               style: theme.textTheme.caption)
         ],
       );


### PR DESCRIPTION
[#518] add `onTap` function to `_TweetTileLeading` in case of retweet. `Navigator` pushes to profile of the user who retweeted