### PR TITLE
FIX [#517] show replies on retweeted tweet

### DIFF
--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -184,8 +184,10 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
   }
 
   void onClickOpenTweet() {
+    var baseTweet = tweet.retweetedStatus ?? tweet;
+
     Navigator.pushNamed(context, routeStatus,
-        arguments: StatusScreenArguments(id: tweet.idStr!, username: tweet.user!.screenName!));
+        arguments: StatusScreenArguments(id: baseTweet.idStr!, username: baseTweet.user!.screenName!));
   }
 
 


### PR DESCRIPTION
BUG FIX [#517]: Add check in `onClickOpenTweet()` function, if tweet is a retweet. In this case it pushes now to `StatusScreen` of the original tweet and not to the retweet, as before.