### PR TITLE
FIX [#509] save retweeted media with originating author

### DIFF
--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -302,7 +302,14 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
 
     Widget media = Container();
     if (tweet.extendedEntities?.media != null && tweet.extendedEntities!.media!.isNotEmpty) {
-      media = TweetMedia(sensitive: tweet.possiblySensitive, media: tweet.extendedEntities!.media!, username: this.tweet.user!.screenName!);
+
+      var baseTweet = this.tweet.retweetedStatus ?? this.tweet;
+
+      media = TweetMedia(
+          sensitive: baseTweet.possiblySensitive,
+          media: baseTweet.extendedEntities!.media!,
+          username: baseTweet.user!.screenName!,
+      );
     }
 
     Widget retweetBanner = Container();


### PR DESCRIPTION
[#509] add check in `TweetTile` build function, whether `media` is in embedded in retweet. If this is the case `TweetMedia` will be constructed with the data from the originating tweet. 