### PR TITLE
add Saved Tweets tab to ProfileScreen

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/next.txt
+++ b/fastlane/metadata/android/en-US/changelogs/next.txt
@@ -14,3 +14,4 @@
 * Added pull-to-refresh and scroll-to-top on profiles (#589)
 * Added support for sharing images (#556 - thanks @ramosmauricio!)
 * Added support for muting media by default (#553 - thanks @johann-gambol!)
+* Added saved tweets as a tab on the profile screen (#549 - thanks @johann-gambol!)

--- a/lib/database/entities.dart
+++ b/lib/database/entities.dart
@@ -13,21 +13,19 @@ mixin ToMappable {
 
 class SavedTweet with ToMappable {
   final String id;
+  final String? user;
   final String? content;
 
-  SavedTweet({required this.id, required this.content});
+  SavedTweet({required this.id, required this.user, required this.content});
 
   factory SavedTweet.fromMap(Map<String, Object?> map) {
-    return SavedTweet(id: map['id'] as String, content: map['content'] as String?);
+    return SavedTweet(id: map['id'] as String, user: map['user_id'] as String?, content: map['content'] as String?);
   }
 
   @override
   Map<String, dynamic> toMap() {
-    return {'id': id, 'content': content};
+    return {'id': id, 'content': content, 'user_id': user};
   }
-
-  String get userId => jsonDecode(content)['user']['id_str'] as String;
-
 }
 
 abstract class Subscription with ToMappable {

--- a/lib/database/entities.dart
+++ b/lib/database/entities.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:fritter/group/group_model.dart';
 import 'package:fritter/user.dart';
@@ -23,6 +25,9 @@ class SavedTweet with ToMappable {
   Map<String, dynamic> toMap() {
     return {'id': id, 'content': content};
   }
+
+  String get userId => jsonDecode(content)['user']['id_str'] as String;
+
 }
 
 abstract class Subscription with ToMappable {

--- a/lib/home/_saved.dart
+++ b/lib/home/_saved.dart
@@ -81,22 +81,33 @@ class _SavedScreenState extends State<SavedScreen> with AutomaticKeepAliveClient
               itemCount: data.length,
               itemBuilder: (context, index) {
                 var item = data[index];
-
-                var content = item.content;
-                if (content == null) {
-                  // The tweet is probably too big to fit inside the cursor and has been removed from the result set
-                  return SavedTweetTooLarge(id: item.id);
-                }
-
-                var tweet = TweetWithCard.fromJson(jsonDecode(content));
-
-                return TweetTile(key: Key(tweet.idStr!), tweet: tweet, clickable: true);
+                return SavedTweetTile(id: item.id, content: item.content);
               },
             );
           },
         ),
       ),
     );
+  }
+}
+
+class SavedTweetTile extends StatelessWidget {
+  final String id;
+  final String? content;
+
+  const SavedTweetTile({Key? key, required this.id, this.content}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    var content = this.content;
+    if (content == null) {
+      // The tweet is probably too big to fit inside the cursor and has been removed from the result set
+      return SavedTweetTooLarge(id: id);
+    }
+
+    var tweet = TweetWithCard.fromJson(jsonDecode(content));
+
+    return TweetTile(key: Key(tweet.idStr!), tweet: tweet, clickable: true);
   }
 }
 

--- a/lib/profile/_saved.dart
+++ b/lib/profile/_saved.dart
@@ -1,0 +1,111 @@
+
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:fritter/client.dart';
+import 'package:fritter/database/entities.dart';
+import 'package:fritter/generated/l10n.dart';
+import 'package:fritter/profile/profile.dart';
+import 'package:fritter/saved/saved_tweet_model.dart';
+import 'package:fritter/tweet/tweet.dart';
+import 'package:fritter/user.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:provider/provider.dart';
+
+import '../ui/errors.dart';
+
+class ProfileSaved extends StatefulWidget {
+
+  final UserWithExtra user;
+
+  const ProfileSaved({Key? key, required this.user}) : super(key: key);
+
+  @override
+  State<ProfileSaved> createState() => _ProfileSavedState();
+}
+
+class _ProfileSavedState extends State<ProfileSaved> {
+
+  late PagingController<int?, SavedTweet> _pagingController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _pagingController = PagingController(firstPageKey: null);
+
+    _pagingController.addPageRequestListener((cursor) {
+      _loadTweets();
+    });
+
+  }
+
+  @override
+  void dispose() {
+
+    _pagingController.dispose();
+
+    super.dispose();
+  }
+
+  Future<void> _loadTweets() async {
+
+    var model = context.read<SavedTweetModel>();
+    await model.listSavedTweets();
+
+    var savedTweets = model.state.where((tweet) => tweet.userId == widget.user.idStr).toList();
+
+    _pagingController.appendLastPage(savedTweets);
+
+  }
+
+  @override
+  Widget build(BuildContext context) {
+
+    return Consumer<TweetContextState>(builder: (context, model, child) {
+      if (model.hideSensitive && (widget.user.possiblySensitive ?? false)) {
+        return EmojiErrorWidget(
+          emoji: '🍆🙈🍆',
+          message: L10n.current.possibly_sensitive,
+          errorMessage: L10n.current.possibly_sensitive_profile,
+          onRetry: () async => model.setHideSensitive(false),
+          retryText: L10n.current.yes_please,
+        );
+      }
+
+      return PagedListView<int?, SavedTweet>(
+        padding: EdgeInsets.zero,
+        pagingController: _pagingController,
+        addAutomaticKeepAlives: false,
+        builderDelegate: PagedChildBuilderDelegate(
+          itemBuilder: (context, savedTweet, index) {
+
+            var tweet = TweetWithCard.fromJson(jsonDecode(savedTweet.content));
+
+            return TweetTile(key: Key(tweet.idStr!), tweet: tweet, clickable: true);
+          },
+          firstPageErrorIndicatorBuilder: (context) => FullPageErrorWidget(
+            error: _pagingController.error[0],
+            stackTrace: _pagingController.error[1],
+            prefix: L10n.of(context).unable_to_load_the_tweets,
+            onRetry: () => _loadTweets(),
+          ),
+          newPageErrorIndicatorBuilder: (context) => FullPageErrorWidget(
+            error: _pagingController.error[0],
+            stackTrace: _pagingController.error[1],
+            prefix: L10n.of(context).unable_to_load_the_next_page_of_tweets,
+            onRetry: () => _loadTweets(),
+          ),
+          noItemsFoundIndicatorBuilder: (context) {
+            return Center(
+              child: Text(
+                L10n.of(context).you_have_not_saved_any_tweets_yet,
+              ),
+            );
+          },
+        ),
+      );
+    });
+  }
+}

--- a/lib/profile/profile.dart
+++ b/lib/profile/profile.dart
@@ -7,6 +7,7 @@ import 'package:fritter/constants.dart';
 import 'package:fritter/database/entities.dart';
 import 'package:fritter/generated/l10n.dart';
 import 'package:fritter/profile/_follows.dart';
+import 'package:fritter/profile/_saved.dart';
 import 'package:fritter/profile/_tweets.dart';
 import 'package:fritter/profile/profile_model.dart';
 import 'package:fritter/search/search.dart';
@@ -122,7 +123,7 @@ class _ProfileScreenBodyState extends State<ProfileScreenBody> with TickerProvid
       nestedScrollViewState.innerController.addListener(_listen);
     });
 
-    _tabController = TabController(length: 5, vsync: this);
+    _tabController = TabController(length: 6, vsync: this);
 
     var description = widget.profile.user.description;
     if (description == null || description.isEmpty) {
@@ -285,6 +286,13 @@ class _ProfileScreenBodyState extends State<ProfileScreenBody> with TickerProvid
                       Tab(
                         child: Text(
                           L10n.of(context).followers,
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                      ///TODO: translation
+                      Tab(
+                        child: Text(
+                          'Saved Tweets',
                           textAlign: TextAlign.center,
                         ),
                       ),
@@ -497,6 +505,7 @@ class _ProfileScreenBodyState extends State<ProfileScreenBody> with TickerProvid
                 ProfileTweets(user: user, type: 'media', includeReplies: false, pinnedTweets: const []),
                 ProfileFollows(user: user, type: 'following'),
                 ProfileFollows(user: user, type: 'followers'),
+                ProfileSaved(user: user),
               ],
             ),
           ),

--- a/lib/saved/saved_tweet_model.dart
+++ b/lib/saved/saved_tweet_model.dart
@@ -30,12 +30,12 @@ class SavedTweetModel extends StreamStore<Object, List<SavedTweet>> {
       var database = await Repository.readOnly();
 
       return (await database.query(tableSavedTweet, orderBy: 'saved_at DESC'))
-          .map((e) => SavedTweet(id: e['id'] as String, content: e['content'] as String?))
+          .map((e) => SavedTweet.fromMap(e))
           .toList();
     });
   }
 
-  Future<void> saveTweet(String id, Map<String, dynamic> content) async {
+  Future<void> saveTweet(String id, String? user, Map<String, dynamic> content) async {
     log.info('Saving tweet with the ID $id');
 
     await execute(() async {
@@ -43,8 +43,8 @@ class SavedTweetModel extends StreamStore<Object, List<SavedTweet>> {
 
       var encodedContent = jsonEncode(content);
 
-      await database.insert(tableSavedTweet, {'id': id, 'content': encodedContent});
-      state.add(SavedTweet(id: id, content: encodedContent));
+      await database.insert(tableSavedTweet, {'id': id, 'user_id': user, 'content': encodedContent});
+      state.add(SavedTweet(id: id, user: user, content: encodedContent));
 
       return state;
     });

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -511,7 +511,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
                                                 } else {
                                                   return createSheetButton(L10n.of(context).save, Icons.bookmark_outline,
                                                           () async {
-                                                        await model.saveTweet(tweet.idStr!, tweet.toJson());
+                                                        await model.saveTweet(tweet.idStr!, tweet.user?.idStr, tweet.toJson());
                                                         Navigator.pop(context);
                                                       });
                                                 }


### PR DESCRIPTION
[#537] Add Request: Saved tweets for profile

Add a 'Saved Tweets' tab to the `ProfileScreen`. To achieve this,  I introduced a `userId` getter to the `SavedTweet` entity, which extracts the id from the `content` property. The `ProfileSaved` tab is more or less identical to the `ProfileTweets` and `ProfileFollows` views.