### PR TITLE
add option to mute Videos by default and remember muting in feed.

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/next.txt
+++ b/fastlane/metadata/android/en-US/changelogs/next.txt
@@ -12,4 +12,5 @@
 * Fixed group deletion not updating the UI (#591)
 * Added support for opening redirect links from emails (#257)
 * Added pull-to-refresh and scroll-to-top on profiles (#589)
-* Added support for sharing images (#556 - thanks to @ramosmauricio!)
+* Added support for sharing images (#556 - thanks @ramosmauricio!)
+* Added support for muting media by default (#553 - thanks @johann-gambol!)

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -8,6 +8,7 @@ const optionHomePages = 'home.pages';
 const optionHomeInitialTab = 'home.initial_tab';
 
 const optionMediaSize = 'media.size';
+const optionsMediaDefaultMute = 'media.mute';
 
 const optionDownloadType = 'download.type';
 const optionDownloadPath = 'download.path';

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -8,7 +8,7 @@ const optionHomePages = 'home.pages';
 const optionHomeInitialTab = 'home.initial_tab';
 
 const optionMediaSize = 'media.size';
-const optionsMediaDefaultMute = 'media.mute';
+const optionMediaDefaultMute = 'media.mute';
 
 const optionDownloadType = 'download.type';
 const optionDownloadPath = 'download.path';

--- a/lib/group/_feed.dart
+++ b/lib/group/_feed.dart
@@ -9,6 +9,7 @@ import 'package:fritter/database/repository.dart';
 import 'package:fritter/generated/l10n.dart';
 import 'package:fritter/group/group_screen.dart';
 import 'package:fritter/profile/profile.dart';
+import 'package:fritter/tweet/_video.dart';
 import 'package:fritter/tweet/conversation.dart';
 import 'package:fritter/ui/errors.dart';
 import 'package:fritter/utils/iterables.dart';
@@ -226,12 +227,17 @@ class _SubscriptionGroupFeedState extends State<SubscriptionGroupFeed> {
       );
     }
 
+    var prefs = PrefService.of(context, listen: false);
+
     return RefreshIndicator(
       onRefresh: () async {
         _pagingController.refresh();
       },
-      child: ChangeNotifierProvider<TweetContextState>(
-        create: (context) => TweetContextState(PrefService.of(context, listen: false).get(optionTweetsHideSensitive)),
+      child: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<TweetContextState>(create: (_) => TweetContextState(prefs.get(optionTweetsHideSensitive))),
+          ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionsMediaDefaultMute))),
+        ],
         child: PagedListView<String?, TweetChain>(
           scrollController: widget.scrollController,
           pagingController: _pagingController,

--- a/lib/group/_feed.dart
+++ b/lib/group/_feed.dart
@@ -236,7 +236,7 @@ class _SubscriptionGroupFeedState extends State<SubscriptionGroupFeed> {
       child: MultiProvider(
         providers: [
           ChangeNotifierProvider<TweetContextState>(create: (_) => TweetContextState(prefs.get(optionTweetsHideSensitive))),
-          ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionsMediaDefaultMute))),
+          ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionMediaDefaultMute))),
         ],
         child: PagedListView<String?, TweetChain>(
           scrollController: widget.scrollController,

--- a/lib/home/_saved.dart
+++ b/lib/home/_saved.dart
@@ -12,6 +12,7 @@ import 'package:fritter/generated/l10n.dart';
 import 'package:fritter/home/home_screen.dart';
 import 'package:fritter/profile/profile.dart';
 import 'package:fritter/saved/saved_tweet_model.dart';
+import 'package:fritter/tweet/_video.dart';
 import 'package:fritter/tweet/tweet.dart';
 import 'package:fritter/ui/errors.dart';
 import 'package:pref/pref.dart';
@@ -41,6 +42,8 @@ class _SavedScreenState extends State<SavedScreen> with AutomaticKeepAliveClient
   Widget build(BuildContext context) {
     var model = context.read<SavedTweetModel>();
 
+    var prefs = PrefService.of(context, listen: false);
+
     return NestedScrollView(
       controller: widget.scrollController,
       headerSliverBuilder: (context, innerBoxIsScrolled) {
@@ -54,8 +57,11 @@ class _SavedScreenState extends State<SavedScreen> with AutomaticKeepAliveClient
           )
         ];
       },
-      body: ChangeNotifierProvider<TweetContextState>(
-        create: (context) => TweetContextState(PrefService.of(context, listen: false).get(optionTweetsHideSensitive)),
+      body: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<TweetContextState>(create: (_) => TweetContextState(prefs.get(optionTweetsHideSensitive))),
+          ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionsMediaDefaultMute))),
+        ],
         child: ScopedBuilder<SavedTweetModel, Object, List<SavedTweet>>.transition(
           store: model,
           onError: (_, e) => FullPageErrorWidget(

--- a/lib/home/_saved.dart
+++ b/lib/home/_saved.dart
@@ -60,7 +60,7 @@ class _SavedScreenState extends State<SavedScreen> with AutomaticKeepAliveClient
       body: MultiProvider(
         providers: [
           ChangeNotifierProvider<TweetContextState>(create: (_) => TweetContextState(prefs.get(optionTweetsHideSensitive))),
-          ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionsMediaDefaultMute))),
+          ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionMediaDefaultMute))),
         ],
         child: ScopedBuilder<SavedTweetModel, Object, List<SavedTweet>>.transition(
           store: model,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -169,7 +169,7 @@ Future<void> main() async {
     optionHomePages: defaultHomePages.map((e) => e.id).toList(),
     optionLocale: optionLocaleDefault,
     optionMediaSize: 'medium',
-    optionsMediaDefaultMute: true,
+    optionMediaDefaultMute: true,
     optionNonConfirmationBiasMode: false,
     optionShouldCheckForUpdates: true,
     optionSubscriptionGroupsOrderByAscending: false,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -169,6 +169,7 @@ Future<void> main() async {
     optionHomePages: defaultHomePages.map((e) => e.id).toList(),
     optionLocale: optionLocaleDefault,
     optionMediaSize: 'medium',
+    optionsMediaDefaultMute: true,
     optionNonConfirmationBiasMode: false,
     optionShouldCheckForUpdates: true,
     optionSubscriptionGroupsOrderByAscending: false,

--- a/lib/profile/profile.dart
+++ b/lib/profile/profile.dart
@@ -10,6 +10,7 @@ import 'package:fritter/profile/_follows.dart';
 import 'package:fritter/profile/_tweets.dart';
 import 'package:fritter/profile/profile_model.dart';
 import 'package:fritter/search/search.dart';
+import 'package:fritter/tweet/_video.dart';
 import 'package:fritter/ui/errors.dart';
 import 'package:fritter/ui/physics.dart';
 import 'package:fritter/user.dart';
@@ -238,6 +239,7 @@ class _ProfileScreenBodyState extends State<ProfileScreenBody> with TickerProvid
     var appBarHeight = profileStuffTop + avatarHeight + metadataHeight + 8 + descriptionHeight;
 
     var metadataTextStyle = const TextStyle(fontSize: 12.5);
+    var prefs = PrefService.of(context, listen: false);
 
     return Scaffold(
       body: Stack(children: [
@@ -481,8 +483,11 @@ class _ProfileScreenBodyState extends State<ProfileScreenBody> with TickerProvid
                       )))
             ];
           },
-          body: ChangeNotifierProvider<TweetContextState>(
-            create: (context) => TweetContextState(PrefService.of(context, listen: false).get(optionTweetsHideSensitive)),
+          body: MultiProvider(
+            providers: [
+              ChangeNotifierProvider<TweetContextState>(create: (_) => TweetContextState(prefs.get(optionTweetsHideSensitive))),
+              ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionsMediaDefaultMute))),
+            ],
             child: TabBarView(
               controller: _tabController,
               physics: const LessSensitiveScrollPhysics(),

--- a/lib/profile/profile.dart
+++ b/lib/profile/profile.dart
@@ -486,7 +486,7 @@ class _ProfileScreenBodyState extends State<ProfileScreenBody> with TickerProvid
           body: MultiProvider(
             providers: [
               ChangeNotifierProvider<TweetContextState>(create: (_) => TweetContextState(prefs.get(optionTweetsHideSensitive))),
-              ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionsMediaDefaultMute))),
+              ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionMediaDefaultMute))),
             ],
             child: TabBarView(
               controller: _tabController,

--- a/lib/search/search.dart
+++ b/lib/search/search.dart
@@ -139,7 +139,7 @@ class _SearchScreenState extends State<_SearchScreen> with SingleTickerProviderS
             MultiProvider(
               providers: [
                 ChangeNotifierProvider<TweetContextState>(create: (_) => TweetContextState(prefs.get(optionTweetsHideSensitive))),
-                ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionsMediaDefaultMute))),
+                ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionMediaDefaultMute))),
               ],
               child: Expanded(
                   child: TabBarView(controller: _tabController, children: [

--- a/lib/search/search.dart
+++ b/lib/search/search.dart
@@ -9,6 +9,7 @@ import 'package:fritter/generated/l10n.dart';
 import 'package:fritter/profile/profile.dart';
 import 'package:fritter/search/search_model.dart';
 import 'package:fritter/subscriptions/users_model.dart';
+import 'package:fritter/tweet/_video.dart';
 import 'package:fritter/tweet/tweet.dart';
 import 'package:fritter/ui/errors.dart';
 import 'package:fritter/user.dart';
@@ -75,6 +76,8 @@ class _SearchScreenState extends State<_SearchScreen> with SingleTickerProviderS
   Widget build(BuildContext context) {
     var subscriptionsModel = context.read<SubscriptionsModel>();
 
+    var prefs = PrefService.of(context, listen: false);
+
     var defaultTheme = Theme.of(context);
     var searchTheme = defaultTheme.copyWith(
       appBarTheme: AppBarTheme(
@@ -133,8 +136,11 @@ class _SearchScreenState extends State<_SearchScreen> with SingleTickerProviderS
                 Tab(icon: Icon(Icons.comment)),
               ]),
             ),
-            ChangeNotifierProvider<TweetContextState>(
-              create: (context) => TweetContextState(PrefService.of(context, listen: false).get(optionTweetsHideSensitive)),
+            MultiProvider(
+              providers: [
+                ChangeNotifierProvider<TweetContextState>(create: (_) => TweetContextState(prefs.get(optionTweetsHideSensitive))),
+                ChangeNotifierProvider<VideoContextState>(create: (_) => VideoContextState(prefs.get(optionsMediaDefaultMute))),
+              ],
               child: Expanded(
                   child: TabBarView(controller: _tabController, children: [
                     TweetSearchResultList<SearchUsersModel, UserWithExtra>(

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -251,6 +251,12 @@ class SettingsGeneralFragment extends StatelessWidget {
                   child: Text(L10n.of(context).large),
                 ),
               ]),
+          /// TODO: translate
+          PrefSwitch(
+            pref: optionsMediaDefaultMute,
+            title: Text('Mute videos'),
+            subtitle: Text('"Whether all videos should be muted by default"'),
+          ),
           PrefCheckbox(
             title: Text(L10n.of(context).hide_sensitive_tweets),
             subtitle: Text(L10n.of(context).whether_to_hide_tweets_marked_as_sensitive),

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -253,7 +253,7 @@ class SettingsGeneralFragment extends StatelessWidget {
               ]),
           /// TODO: translate
           PrefSwitch(
-            pref: optionsMediaDefaultMute,
+            pref: optionMediaDefaultMute,
             title: Text('Mute videos'),
             subtitle: Text('"Whether all videos should be muted by default"'),
           ),

--- a/lib/tweet/_video.dart
+++ b/lib/tweet/_video.dart
@@ -7,6 +7,7 @@ import 'package:fritter/tweet/_video_controls.dart';
 import 'package:fritter/utils/downloads.dart';
 import 'package:fritter/utils/iterables.dart';
 import 'package:path/path.dart' as path;
+import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 import 'package:wakelock/wakelock.dart';
@@ -70,6 +71,14 @@ class _TweetVideoState extends State<TweetVideo> {
     var downloadUrl = urls.downloadUrl;
 
     _videoController = VideoPlayerController.network(streamUrl!);
+
+    var model = context.read<VideoContextState>();
+    var volume = model.isMuted ? 0.0 : _videoController!.value.volume;
+    _videoController!.setVolume(volume);
+
+    _videoController!.addListener(() {
+        model.setIsMuted(_videoController!.value!.volume);
+    });
 
     _chewieController = ChewieController(
       aspectRatio: widget.metadata.aspectRatio,
@@ -218,3 +227,21 @@ class _VideoState extends State<_Video> {
     );
   }
 }
+
+class VideoContextState extends ChangeNotifier{
+
+  bool isMuted;
+
+  VideoContextState(this.isMuted);
+
+  void setIsMuted(double volume){
+
+    if(isMuted && volume > 0 || !isMuted && volume == 0){
+      isMuted = !isMuted;
+    }
+
+  }
+
+}
+
+


### PR DESCRIPTION
I added one more option to the general settings tab, addressing the media:

    default muting: All videos will be muted by default

This option is true by default.

In addition to that, I introduced `VideoContextState`. This class stores the user's decision to mute or unmute videos for the current feed. It works identical as the `TweetContextState`.
