### PR TITLE
Improve non-confirmation-bias mode

### DIFF
--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -183,6 +183,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "fritter": MessageLookupByLibrary.simpleMessage("Fritter"),
         "fritter_blue": MessageLookupByLibrary.simpleMessage("Fritter blau"),
         "general": MessageLookupByLibrary.simpleMessage("Allgemeines"),
+        "generic_username": MessageLookupByLibrary.simpleMessage("Benutzer"),
         "groups": MessageLookupByLibrary.simpleMessage("Gruppen"),
         "help_make_fritter_even_better": MessageLookupByLibrary.simpleMessage(
             "Dazu beitragen, Fritter noch besser zu machen"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -184,6 +184,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "fritter": MessageLookupByLibrary.simpleMessage("Fritter"),
         "fritter_blue": MessageLookupByLibrary.simpleMessage("Fritter blue"),
         "general": MessageLookupByLibrary.simpleMessage("General"),
+        "generic_username": MessageLookupByLibrary.simpleMessage("User"),
         "group_name": m20,
         "groups": MessageLookupByLibrary.simpleMessage("Groups"),
         "help_make_fritter_even_better": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -2466,6 +2466,16 @@ class L10n {
       args: [],
     );
   }
+
+  /// `User`
+  String get generic_username {
+    return Intl.message(
+      'User',
+      name: 'generic_username',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -422,5 +422,6 @@
   "hide_sensitive_tweets": "Sensible Tweets ausblenden",
   "whether_to_hide_tweets_marked_as_sensitive": "Ob Tweets, die als sensibel markiert sind, ausgeblendet werden sollen",
   "disable_screenshots": "Screenshots deaktivieren",
-  "disable_screenshots_hint": "Versucht zu verhindern, dass Screenshots von Fritter gemacht werden können. Dies ist keine Garantie und funktioniert möglicherweise nicht auf allen Geräten."
+  "disable_screenshots_hint": "Versucht zu verhindern, dass Screenshots von Fritter gemacht werden können. Dies ist keine Garantie und funktioniert möglicherweise nicht auf allen Geräten.",
+  "generic_username": "Benutzer"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -431,5 +431,6 @@
   "search_term": "Search term",
   "only_public_subscriptions_can_be_imported": "Subscriptions can only be imported from public profiles",
   "unsupported_url": "Unsupported URL",
-  "saved_tweet_too_large": "This saved tweet could not be displayed, as it's too big to load. Please report it to the developers."
+  "saved_tweet_too_large": "This saved tweet could not be displayed, as it's too big to load. Please report it to the developers.",
+  "generic_username": "User"
 }

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -471,7 +471,10 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
                                 child: Row(
                                   children: [
                                     Flexible(
-                                        child: Text(tweet.user!.name!,
+                                        child: Text(
+                                            hideAuthorInformation
+                                                ? L10n.of(context).generic_username
+                                                : tweet.user!.name!,
                                             overflow: TextOverflow.ellipsis,
                                             style: const TextStyle(fontWeight: FontWeight.w500))),
                                     if (tweet.user!.verified ?? false) const SizedBox(width: 4),
@@ -568,7 +571,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
                         ),
                         // Profile picture
                         leading: hideAuthorInformation
-                            ? null
+                            ? const Icon(Icons.account_circle_rounded, size: 48)
                             : ClipRRect(
                                 borderRadius: BorderRadius.circular(64),
                                 child: UserAvatar(uri: tweet.user!.profileImageUrlHttps),

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -480,9 +480,10 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
                                               : tweet.user!.name!,
                                           overflow: TextOverflow.ellipsis,
                                           style: const TextStyle(fontWeight: FontWeight.w500))),
-                                  if (tweet.user!.verified ?? false) const SizedBox(width: 4),
-                                  if (tweet.user!.verified ?? false)
+                                  if (!hideAuthorInformation && (tweet.user!.verified ?? false)) ...[
+                                    const SizedBox(width: 4),
                                     Icon(Icons.verified, size: 18, color: Theme.of(context).primaryColor)
+                                  ]
                                 ],
                               ),
                             ),

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -470,23 +470,22 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
                         title: Row(
                           children: [
                             // Username
-                            if (!hideAuthorInformation)
-                              Flexible(
-                                child: Row(
-                                  children: [
-                                    Flexible(
-                                        child: Text(
-                                            hideAuthorInformation
-                                                ? L10n.of(context).generic_username
-                                                : tweet.user!.name!,
-                                            overflow: TextOverflow.ellipsis,
-                                            style: const TextStyle(fontWeight: FontWeight.w500))),
-                                    if (tweet.user!.verified ?? false) const SizedBox(width: 4),
-                                    if (tweet.user!.verified ?? false)
-                                      Icon(Icons.verified, size: 18, color: Theme.of(context).primaryColor)
-                                  ],
-                                ),
+                            Flexible(
+                              child: Row(
+                                children: [
+                                  Flexible(
+                                      child: Text(
+                                          hideAuthorInformation
+                                              ? L10n.of(context).generic_username
+                                              : tweet.user!.name!,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: const TextStyle(fontWeight: FontWeight.w500))),
+                                  if (tweet.user!.verified ?? false) const SizedBox(width: 4),
+                                  if (tweet.user!.verified ?? false)
+                                    Icon(Icons.verified, size: 18, color: Theme.of(context).primaryColor)
+                                ],
                               ),
+                            ),
                             const Spacer(),
                             InkWell(
                               child: const Icon(Icons.more_horiz),

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -285,11 +285,15 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
   @override
   Widget build(BuildContext context) {
     final prefs = PrefService.of(context, listen: false);
-    final hideAuthorInformation = prefs.get(optionNonConfirmationBiasMode);
-    var numberFormat = NumberFormat.compact();
-    var theme = Theme.of(context);
 
     TweetWithCard tweet = this.tweet.retweetedStatusWithCard == null ? this.tweet : this.tweet.retweetedStatusWithCard!;
+
+    // If the user is on a profile, all the shown tweets are from that profile, so it makes no sense to hide it
+    final isTweetOnSameProfile = currentUsername != null && currentUsername == tweet.user!.screenName;
+    final hideAuthorInformation = !isTweetOnSameProfile && prefs.get(optionNonConfirmationBiasMode);
+
+    var numberFormat = NumberFormat.compact();
+    var theme = Theme.of(context);
 
     if (tweet.isTombstone ?? false) {
       return SizedBox(


### PR DESCRIPTION
This PR includes a better non-confirmation-bias mode.

![image](https://user-images.githubusercontent.com/50424412/207388669-589fc376-801f-4a43-bcf4-73dc440bddfe.png)

Usernames and profiles are hidden.

![image](https://user-images.githubusercontent.com/50424412/207388838-f53cfa59-df05-4a03-9f54-5eb80978e5ad.png)

Except you're on the profile, as it doesn't make any sense to hide it then.

![image](https://user-images.githubusercontent.com/50424412/207388938-5292e144-e38e-4ccf-8c84-b2261873a8f0.png)

But if the user retweets something, the other user is hidden again. :)