### PR TITLE
Support for opening t.co links by default

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -79,6 +79,14 @@
                     android:host="www.twitter.com"
                     android:scheme="https" />
 
+                <data
+                    android:host="t.co"
+                    android:scheme="http" />
+
+                <data
+                    android:host="t.co"
+                    android:scheme="https" />
+
                 <!-- Discord embedding websites -->
                 <data
                     android:host="fxtwitter.com"


### PR DESCRIPTION
#273 -- t.co is a link shortener that Twitter uses. It's often used for internal and external links. Can Fritter open t.co by default; is enabling it this simple?