### PR TITLE
fix the missing blue checks in timelines, in profile and in tweet detail

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -661,7 +661,8 @@ class TweetWithCard extends Tweet {
   factory TweetWithCard.fromGraphqlJson(Map<String, dynamic> result) {
     var retweetedStatus = result['retweeted_status_result'] == null ? null : TweetWithCard.fromGraphqlJson(result['retweeted_status_result']['result']);
     var quotedStatus = result['quoted_status_result'] == null ? null : TweetWithCard.fromGraphqlJson(result['quoted_status_result']['result']);
-    var user = result['core']?['user_results']?['result']?['legacy'] == null ? null : UserWithExtra.fromJson(result['core']['user_results']['result']['legacy']);
+    var resCore = result['core']?['user_results']?['result'];
+    var user = resCore?['legacy'] == null ? null : UserWithExtra.fromJson({...resCore['legacy'], 'id_str': resCore['rest_id'], 'ext_is_blue_verified': resCore['is_blue_verified']});
 
     String? noteText;
     Entities? noteEntities;

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -270,7 +270,7 @@ class Twitter {
       }
     }
 
-    var user = UserWithExtra.fromJson({...result['legacy'], 'id_str': result['rest_id']});
+    var user = UserWithExtra.fromJson({...result['legacy'], 'id_str': result['rest_id'], 'ext_is_blue_verified': result['is_blue_verified']});
     var pins = List<String>.from(result['legacy']['pinned_tweet_ids_str']);
 
     return Profile(user, pins);

--- a/lib/user.dart
+++ b/lib/user.dart
@@ -203,7 +203,7 @@ class UserWithExtra extends User {
           : UserEntities.fromJson(json['entities'] as Map<String, dynamic>)
       ..description = json['description'] as String?
       ..protected = json['protected'] as bool?
-      ..verified = json['verified'] as bool?
+      ..verified = json['ext_is_blue_verified'] ?? json['verified'] as bool?
       ..status = json['status'] == null
           ? null
           : Tweet.fromJson(json['status'] as Map<String, dynamic>)


### PR DESCRIPTION
In the response of the timeline request, the users under _globalObjects_ have a property _ext_is_blue_verified_ that tells if they have a blue check or not. (In that response, the _verified_ property of the users seems to always be _false_, so not useful).

In the response of the profile request, under _result_ there is a _is_blue_verified_ property that tells if the user has a blue check or not. (In that response, the _verified_ property under _legacy_ also seems to always be _false_, so not useful).

In the response of the graphql TweetDetail request, under _result_ there is a _is_blue_verified_ property that tells if the user has a blue check or not. (In that response, the _verified_ property under _legacy_ also seems to always be _false_, so not useful).