### PR TITLE
fix getting the cursor from the graphql TweetDetail request

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -460,8 +460,10 @@ class Twitter {
       var content = cursorEntry['content'];
       if (content.containsKey('value')) {
         cursor = content['value'];
-      } else {
+      } else if (content.containsKey('operation')) {
         cursor = content['operation']['cursor']['value'];
+      } else {
+        cursor = content['itemContent']['value'];
       }
     } else {
       // Look for a "replaceEntry" with the cursor


### PR DESCRIPTION
the cursor from the _graphql_ _TweetDetail_ request comes from an _itemContent_ key instead of an _operation_ or _value_ key.

this should fix the bug #685.