### PR TITLE
fix the exception of drawable/ic_notification that causes a crash at startup of the release version

### DIFF
--- a/android/app/src/main/res/raw/keep.xml
+++ b/android/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+           tools:keep="@drawable/ic_*" />


### PR DESCRIPTION
This is to fix the bugs #691, #594 and #575.

When launching the app of the latest released beta version (beta8), the app crashes immediately.

Looking at the logcat output, the relevant part is:
```
05-01 15:42:49.850  4069  4069 E Icon    : Unable to load resource 0x7f040000 from pkg=com.jonjomckay.fritter
05-01 15:42:49.850  4069  4069 E Icon    : android.content.res.Resources$NotFoundException: Drawable com.jonjomckay.fritter:drawable/ic_notification with resource ID #0x7f040000
...
```
The ic_notification resource is not found on the release version.

The added keep.xml file helps fix the problem.

Reference: [Android Shrink Resources, Resource Not Found](https://shrikanth.in/android/issues/2020/07/05/shrink-resources-not-found.html).
