### PR TITLE
RFE to make the app on android moveable to an sd-card

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
-    package="com.jonjomckay.fritter">
+    package="com.jonjomckay.fritter" android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
With this setting, it is possible for a user to move the app on the android smartphone's sd-card, if present.
The app is always installed in the smartphone's internal memory first. 
With this setting, a user can later choose to move the app to the smartphone's sd-card, if present, to free space on the smartphone's internal memory.