### PR TITLE
fix to allow storage permission for Android 11+

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,9 +6,11 @@
     <!-- Force usage of the file picker library even on SDKs < 19, as we handle it at runtime -->
     <uses-sdk tools:overrideLibrary="com.kineapps.flutter_file_dialog" />
 
-    <!-- Required for importing and exporting on older versions of Android (<19?) -->
+    <!-- Required for importing and exporting on older versions of Android (<=10) -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- Permission for the Android 11 and above -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -351,7 +351,9 @@ class DownloadTypeSettingState extends State<DownloadTypeSetting> {
         if (PrefService.of(context).get(optionDownloadType) == optionDownloadTypeDirectory)
           PrefButton(
             onTap: () async {
-              var storagePermission = await Permission.storage.request();
+              DeviceInfoPlugin plugin = DeviceInfoPlugin();
+              AndroidDeviceInfo android = await plugin.androidInfo;
+              var storagePermission = android.version.sdkInt < 30 ? await Permission.storage.request() : await Permission.manageExternalStorage.request();
               if (storagePermission.isGranted) {
                 String? directoryPath = await FilePicker.platform.getDirectoryPath();
                 if (directoryPath == null) {

--- a/lib/utils/downloads.dart
+++ b/lib/utils/downloads.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:fritter/catcher/errors.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_file_dialog/flutter_file_dialog.dart';
@@ -35,7 +36,9 @@ Future<void> downloadUriToPickedFile(BuildContext context, Uri uri, String fileN
       onStart();
       var responseTask = downloadFile(context, uri);
 
-      var storagePermission = await Permission.storage.request();
+      DeviceInfoPlugin plugin = DeviceInfoPlugin();
+      AndroidDeviceInfo android = await plugin.androidInfo;
+      var storagePermission = android.version.sdkInt < 30 ? await Permission.storage.request() : await Permission.manageExternalStorage.request();
 
       var response = await responseTask;
       if (response == null) {


### PR DESCRIPTION
This is a follow up of the [Quaker's issue #67](https://github.com/TheHCJ/Quacker/issues/67) in the case of devices with Android 11+.

This is to allow storage permission to download automatically to directory for devices with Android 11+.