### PR TITLE
Fix that touching the RT account names gives an error.

### DIFF
--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -319,7 +319,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
     if (this.tweet.retweetedStatusWithCard != null) {
       retweetBanner = _TweetTileLeading(
         icon: Icons.repeat,
-        onTap: () => Navigator.pushNamed(context, routeProfile, arguments: this.tweet.user!.screenName!),
+        onTap: () => Navigator.pushNamed(context, routeProfile, arguments: ProfileScreenArguments.fromScreenName(this.tweet.user!.screenName!)),
         children: [
           TextSpan(
               text: L10n.of(context)


### PR DESCRIPTION
When a RT account name in a tweet banner is touched, it gives an error.
It should redirect to the account profile.
This fixes it.
Reference: [Squawker's issue 13](https://github.com/j-fbriere/squawker/issues/13).