### PR TITLE
Fix the black screen when app is in recent screen mode.

### DIFF
--- a/android/app/src/main/kotlin/com/jonjomckay/fritter/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/jonjomckay/fritter/MainActivity.kt
@@ -3,4 +3,13 @@ package com.jonjomckay.fritter
 import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity: FlutterActivity() {
+
+    protected override fun onPause() {
+        super.onPause()
+        try {
+            java.lang.Thread.sleep(200)
+        } catch (e: InterruptedException) {
+            e.printStackTrace()
+        }
+    }
 }


### PR DESCRIPTION
This is just a minor annoyance.
This fixes the black screen when the app is in recent screen mode.
Before the fix:
![recent_screen_black](https://github.com/jonjomckay/fritter/assets/49044668/4df558aa-ff17-4103-bf4e-1ff6376c01a2)
After the fix:
![recent_screen_fixed](https://github.com/jonjomckay/fritter/assets/49044668/b055c94f-92e1-425c-8342-5bd347a5cbfc)
